### PR TITLE
Fix completely broken logic about the size of the kernel binary in the cuda backend.

### DIFF
--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -25,7 +25,7 @@ cdef object PyArray_Empty(int a, np.npy_intp *b, np.dtype c, int d):
 cdef object call_compiler_fn = None
 
 cdef void *call_compiler_python(const char *src, size_t sz,
-                                int *ret) with gil:
+                                size_t *bin_len, int *ret) with gil:
     cdef bytes res
     cdef void *buf
     cdef char *tmp
@@ -38,6 +38,7 @@ cdef void *call_compiler_python(const char *src, size_t sz,
             return NULL
         tmp = res
         memcpy(buf, tmp, len(res))
+        bin_len[0] = len(res);
         return buf
     except:
         # XXX: maybe should store the exception somewhere
@@ -45,7 +46,7 @@ cdef void *call_compiler_python(const char *src, size_t sz,
             ret[0] = GA_RUN_ERROR
         return NULL
 
-ctypedef void *(*comp_f)(const char *, size_t, int*)
+ctypedef void *(*comp_f)(const char *, size_t, size_t *, int*)
 
 def set_cuda_compiler_fn(fn):
     """

--- a/src/gpuarray/ext_cuda.h
+++ b/src/gpuarray/ext_cuda.h
@@ -15,7 +15,7 @@ static CUstream (*cuda_get_stream)(void *);
 static gpudata *(*cuda_make_buf)(void *, CUdeviceptr, size_t);
 static CUdeviceptr (*cuda_get_ptr)(gpudata *);
 static size_t (*cuda_get_sz)(gpudata *);
-static void (*cuda_set_compiler)(void *(*)(const char *, size_t, int *));
+static void (*cuda_set_compiler)(void *(*)(const char *, size_t, size_t *, int *));
 
 static void setup_ext_cuda(void) {
   // The casts are necessary to reassure C++ compilers
@@ -27,7 +27,7 @@ static void setup_ext_cuda(void) {
   cuda_make_buf = (gpudata *(*)(void *, CUdeviceptr, size_t))gpuarray_get_extension("cuda_make_buf");
   cuda_get_ptr = (CUdeviceptr (*)(gpudata *))gpuarray_get_extension("cuda_get_ptr");
   cuda_get_sz = (size_t (*)(gpudata *))gpuarray_get_extension("cuda_get_sz");
-  cuda_set_compiler = (void (*)(void *(*)(const char *, size_t, int *)))gpuarray_get_extension("cuda_set_compiler");
+  cuda_set_compiler = (void (*)(void *(*)(const char *, size_t, size_t *, int *)))gpuarray_get_extension("cuda_set_compiler");
 }
 
 #endif


### PR DESCRIPTION
This makes retriveing the kernel binary using ops->kernel_binary() on the cuda backend:
- not useless / wrong
- not a potential source of crashes
