### PR TITLE
Added mako in dependency list

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -24,7 +24,7 @@ Requirements
  - (optional) clBLAS (clblas_).
  - (optional) libcheck (check_) to run the C tests.
  - (optional) python (python_) for the python bindings.
- - (optional) mako (mako_) at build time for python bindings.
+ - (optional) mako (mako_) for development or running the python bindings.
  - (optional) Cython >= 0.19 (cython_) for the python bindings.
  - (optional) nosetests (nosetests_) to run the python tests.
 


### PR DESCRIPTION
It's needed to compile (at least on Windows) and it's not on this list, and I don't want anyone else to spend 20 minutes finding this out the hard way.
