### PR TITLE
Fix OpenCL CL_DRIVER_VERSION query from causing GPU selection to fail.

### DIFF
--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -49,7 +49,7 @@ cl_ctx *cl_make_ctx(cl_context ctx) {
   cl_device_id id;
   cl_command_queue_properties qprop;
   char vendor[32];
-  char driver_version[16];
+  char driver_version[64];
   cl_uint vendor_id;
   size_t len;
 
@@ -748,7 +748,7 @@ static gpukernel *cl_newkernel(void *c, unsigned int count,
 
       strb debug_msg = STRB_STATIC_INIT;
       // We're substituting debug_msg for a string with this first line:
-      strb_appends(&debug_msg, "Program build failure ::\n"); 
+      strb_appends(&debug_msg, "Program build failure ::\n");
 
       // Determine the size of the log
       size_t log_size;
@@ -857,7 +857,7 @@ static int cl_callkernel(gpukernel *k, size_t ls[2], size_t gs[2],
   if (evw == NULL) {
     return GA_MEMORY_ERROR;
   }
-  
+
   for (i = 0; i < k->argcount; i++) {
     if (k->types[i] == GA_BUFFER) {
       btmp = (gpudata *)args[i];


### PR DESCRIPTION
On some OpenCL GPUs, an exception, "pygpu.gpuarray.GpuArrayException: Invalid value", is thrown when initializing a GpuContext.

$ python -c "import pygpu; print pygpu.init('opencl0:1').devname"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "pygpu/gpuarray.pyx", line 587, in pygpu.gpuarray.init (pygpu/gpuarray.c:7506)
  File "pygpu/gpuarray.pyx", line 558, in pygpu.gpuarray.pygpu_init (pygpu/gpuarray.c:7435)
  File "pygpu/gpuarray.pyx", line 962, in pygpu.gpuarray.GpuContext.__cinit__ (pygpu/gpuarray.c:11098)
pygpu.gpuarray.GpuArrayException: Invalid value

This seems to occur because the driver_version buffer is not big enough to accommodate long device driver string signatures. 

When the following OpenCL function is called

```C
  err = clGetDeviceInfo(id, CL_DRIVER_VERSION, sizeof(driver_version),
                        driver_version, NULL);
  if (err != CL_SUCCESS)
    return NULL;
```

It fails and exits the entire GpuContext initialization routine.

With my GPU, an AMD Radeon HD 7950, the driver version is listed as "1.2 (Aug 17 2014 20:27:52)", which is a combination of the driver version and device version strings, and it overflows the current 16 byte buffer.

This PR is a simple fix that increases the size of the driver_version string and it should fix problems reported in issue #34.