### PR TITLE
Prevent redefinition of max_align_t

### DIFF
--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -594,7 +594,7 @@ def init(dev):
     For opencl the device id is the platform number, a colon (:) and
     the device number.  There are no widespread and/or easy way to
     list available platforms and devices.  You can experiement with
-    the values, unavaiable ones will just raise an error, and there
+    the values, unavailable ones will just raise an error, and there
     are no gaps in the valid numbers.
     """
     return pygpu_init(dev)

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -227,7 +227,7 @@ static const char *get_error_string(CUresult err) {
     case CUDA_ERROR_OUT_OF_MEMORY:     return "Out of host memory";
     case CUDA_ERROR_NOT_INITIALIZED:   return "API not initialized";
     case CUDA_ERROR_DEINITIALIZED:     return "Driver is shutting down";
-    case CUDA_ERROR_NO_DEVICE:         return "No CUDA devices avaiable";
+    case CUDA_ERROR_NO_DEVICE:         return "No CUDA devices available";
     case CUDA_ERROR_INVALID_DEVICE:    return "Invalid device ordinal";
     case CUDA_ERROR_INVALID_IMAGE:     return "Invalid module image";
     case CUDA_ERROR_INVALID_CONTEXT:   return "No context bound to current thread or invalid context parameter";

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -621,6 +621,7 @@ static int cl_memset(gpudata *dst, size_t offset, int data) {
   }
   /* If this assert fires, increase the size of local_kern above. */
   assert(r <= sizeof(local_kern));
+  (void)r; // Remove 'unused' variable warning, no run-time penalty
 
   sz = strlen(local_kern);
   rlk[0] = local_kern;

--- a/src/util/halloc.c
+++ b/src/util/halloc.c
@@ -48,6 +48,7 @@
 
 #define structof(p,t,f) ((t*)(- offsetof(t,f) + (void*)(p)))
 
+#ifndef _GCC_MAX_ALIGN_T
 union max_align
 {
   char   c;
@@ -61,6 +62,7 @@ union max_align
 };
 
 typedef union max_align max_align_t;
+#endif
 
 /*
  *      weak double-linked list w/ tail sentinel


### PR DESCRIPTION
This addresses issue #55 (and fixes a couple of typos, and cures a spurious warning).