### PR TITLE
Fix compilation with C11 or C++11 enabled (default on GCC 5).

### DIFF
--- a/src/util/halloc.c
+++ b/src/util/halloc.c
@@ -48,6 +48,8 @@
 
 #define structof(p,t,f) ((t*)(- offsetof(t,f) + (void*)(p)))
 
+#ifndef _GCC_MAX_ALIGN_T
+#define _GCC_MAX_ALIGN_T
 union max_align
 {
   char   c;
@@ -61,6 +63,7 @@ union max_align
 };
 
 typedef union max_align max_align_t;
+#endif
 
 /*
  *      weak double-linked list w/ tail sentinel


### PR DESCRIPTION
GCC 5 enables C11 by default, and stddef already creates struct max_align and max_align_t.

In order to compile libgpuarray you can either disable C11/C++11 on the CMakeLists (undesirable IMHO), or avoid redeclaring the struct if it has already been declared. This patch does just that. I decided not to remove the struct declaration altogether, in order to keep the support for older versions of the standard.