### PR TITLE
Two small fixes

### DIFF
--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -213,8 +213,10 @@ cdef np.dtype dtype_to_npdtype(dtype):
         return None
     if isinstance(dtype, int):
         return typecode_to_dtype(dtype)
-    if isinstance(dtype, str):
+    try:
         return np.dtype(dtype)
+    except TypeError:
+        pass
     if isinstance(dtype, np.dtype):
         return dtype
     raise ValueError("data type not understood", dtype)
@@ -236,8 +238,10 @@ cpdef int dtype_to_typecode(dtype) except -1:
     """
     if isinstance(dtype, int):
         return dtype
-    if isinstance(dtype, str):
+    try:
         dtype = np.dtype(dtype)
+    except TypeError:
+        pass
     if isinstance(dtype, np.dtype):
         res = NP_TO_TYPE.get(dtype, None)
         if res is not None:

--- a/pygpu/tools.py
+++ b/pygpu/tools.py
@@ -95,9 +95,9 @@ def check_args(args, collapse=False, broadcast=False):
             strs.append(None)
             offsets.append(None)
 
-        if len(arrays) < 1:
-            raise TypeError("No arrays in kernel arguments, "
-                            "something is wrong")
+    if len(arrays) < 1:
+        raise TypeError("No arrays in kernel arguments, "
+                        "something is wrong")
     n = arrays[0].size
     nd = arrays[0].ndim
     dims = arrays[0].shape


### PR DESCRIPTION
Hi, here are two small changes:
- in gpuarray.pyx, allow arrays to be created like empty(shape, dtype=numpy.float32).
- in tools.py, fix a bug that was throwing an exception if a binary function had a scalar and a vector argument.
