### PR TITLE
Two fixes and a suggestion for check_args()

### DIFF
--- a/pygpu/elemwise.py
+++ b/pygpu/elemwise.py
@@ -2,7 +2,7 @@ from mako.template import Template
 
 import numpy
 
-from .tools import ScalarArg, ArrayArg, as_argument, check_args, lfu_cache
+from .tools import ScalarArg, ArrayArg, as_argument, check_contig, check_args, lfu_cache
 from .dtypes import (parse_c_arg_backend, dtype_to_ctype, get_np_obj,
                      get_common_dtype)
 from . import gpuarray
@@ -428,11 +428,13 @@ class ElemwiseKernel(object):
         return k, args
 
     def select_kernel(self, args, collapse=None, broadcast=False):
+        n, offsets, contig = check_contig(args)
+        if contig:
+            return (self.contig_k, self.prepare_args_contig(args, n, offsets)), n
+
         n, nd, dims, strs, offsets, contig = check_args(args,
                                                         collapse=collapse,
                                                         broadcast=broadcast)
-        if contig:
-            return (self.contig_k, self.prepare_args_contig(args, n, offsets)), n
 
         try:
             return self.try_specialized(args, n, nd, dims, strs, offsets), n
@@ -480,8 +482,7 @@ class ElemwiseKernel(object):
             k(*args, n=n)
 
     def call_contig(self, *args):
-        n, nd, dims, strs, offsets, contig = check_args(args, collapse=False,
-                                                        broadcast=False)
+        n, offsets, contig = check_contig(args)
         if not contig:
             raise ValueError("Can't call contig on non-contiguous data")
         if n != 0:

--- a/pygpu/tests/test_tools.py
+++ b/pygpu/tests/test_tools.py
@@ -1,9 +1,28 @@
 from pygpu.tools import (as_argument, Argument, ArrayArg, ScalarArg,
-                         check_args, Counter, lfu_cache)
+                         check_contig, check_args, Counter, lfu_cache)
 
 
 from .support import (guard_devsup, rand, check_flags, check_meta, check_all,
                       context, gen_gpuarray, dtypes_no_complex)
+
+
+def test_check_contig_1():
+    ac, ag = gen_gpuarray((50, 1, 20), 'float32', ctx=context)
+    bc, bg = gen_gpuarray((50, 1, 20), 'float32', ctx=context)
+    n, offsets, contig = check_contig((ag, bg))
+    assert n == 1000
+    assert offsets == (0, 0)
+    assert contig
+
+
+def test_check_contig_2():
+    ac, ag = gen_gpuarray((50, 1, 20), 'float32', ctx=context)
+    bc, bg = gen_gpuarray((50, 1, 20), 'float32', ctx=context, sliced=2)
+    n, offsets, contig = check_contig((ag, bg))
+    assert n == None
+    assert offsets == None
+    assert not contig
+
 
 def test_check_args_simple():
     ac, ag = gen_gpuarray((50,), 'float32', ctx=context)
@@ -26,6 +45,7 @@ def test_check_args_simple():
     assert offsets == (0, 0)
     assert contig
 
+
 def test_check_args_collapse_1():
     ac, ag = gen_gpuarray((50, 1, 20), 'float32', ctx=context)
     bc, bg = gen_gpuarray((50, 1, 20), 'float32', ctx=context)
@@ -46,7 +66,7 @@ def test_check_args_collapse_1():
     assert contig
 
 
-def test_check_args_collpse_2():
+def test_check_args_collapse_2():
     ac, ag = gen_gpuarray((50, 1, 20), 'float32', ctx=context, sliced=2,
                           offseted_inner=True)
     bc, bg = gen_gpuarray((50, 1, 20), 'float32', ctx=context)
@@ -71,6 +91,27 @@ def test_check_args_collapse_3():
     assert offsets == (80, 0)
     assert not contig
 
+
+def test_check_args_collapse_4():
+    ac, ag = gen_gpuarray((1,), 'float32', ctx=context)
+    n, nd, dims, strs, offsets, contig = check_args((ag,), collapse=False)
+    assert n == 1
+    assert nd == 1
+    assert dims == (1,)
+    assert strs == ((4,),)
+    assert offsets == (0,)
+    assert contig
+
+    ac, ag = gen_gpuarray((1, 1), 'float32', ctx=context)
+    n, nd, dims, strs, offsets, contig = check_args((ag,), collapse=True)
+    assert n == 1
+    assert nd == 1
+    assert dims == (1,)
+    assert strs == ((4,),)
+    assert offsets == (0,)
+    assert contig
+
+
 def test_check_args_broadcast_1():
     ac, ag = gen_gpuarray((1,), 'float32', ctx=context)
     bc, bg = gen_gpuarray((50,), 'float32', ctx=context)
@@ -81,6 +122,7 @@ def test_check_args_broadcast_1():
     assert strs == ((0,), (4,))
     assert offsets == (0, 0)
     assert not contig
+
 
 def test_check_args_broadcast_2():
     ac, ag = gen_gpuarray((50, 1, 20), 'float32', ctx=context, sliced=2,
@@ -93,4 +135,16 @@ def test_check_args_broadcast_2():
     assert dims == (50, 20)
     assert strs == ((168, 4), (80, 4))
     assert offsets == (4, 0)
+    assert not contig
+
+
+def test_check_args_broadcast_3():
+    ac, ag = gen_gpuarray((10, 20, 30), 'float32', ctx=context)
+    bc, bg = gen_gpuarray((1, 1, 1), 'float32', ctx=context)
+    n, nd, dims, strs, offsets, contig = check_args((ag, bg), broadcast=True)
+    assert n == 6000
+    assert nd == 3
+    assert dims == (10, 20, 30)
+    assert strs == ((2400, 120, 4), (0, 0, 0))
+    assert offsets == (0, 0)
     assert not contig

--- a/pygpu/tools.py
+++ b/pygpu/tools.py
@@ -67,6 +67,27 @@ class ScalarArg(Argument):
     def spec(self):
         return self.dtype
 
+def check_contig(args):
+    dims = None
+    c_contig = f_contig = True
+    offsets = []
+    for arg in args:
+        if not isinstance(arg, GpuArray):
+            offsets.append(None)
+            continue
+
+        if dims is None:
+            dims = arg.shape
+            n = arg.size
+        elif arg.shape != dims:
+            return None, None, False
+        offsets.append(arg.offset)
+        fl = arg.flags
+        c_contig = c_contig and fl['C_CONTIGUOUS']
+        f_contig = f_contig and fl['F_CONTIGUOUS']
+    if not (c_contig or f_contig):
+        return None, None, False
+    return n, offsets, True
 
 def check_args(args, collapse=False, broadcast=False):
     """

--- a/pygpu/tools.py
+++ b/pygpu/tools.py
@@ -156,7 +156,7 @@ def check_args(args, collapse=False, broadcast=False):
             strs = [list(str) if str is not None else str for str in strs]
         collapse = True
 
-    if nd > 1 and collapse:
+    if collapse:
         # remove dimensions that are of size 1
         for i in range(nd-1, -1, -1):
             if dims[i] == 1:
@@ -176,6 +176,7 @@ def check_args(args, collapse=False, broadcast=False):
                         str[i-1] = str[i]
                         del str[i]
                 nd -= 1
+
     if broadcast or collapse:
         # re-wrap dims and tuples
         dims = tuple(dims)

--- a/pygpu/tools.py
+++ b/pygpu/tools.py
@@ -87,7 +87,7 @@ def check_contig(args):
         f_contig = f_contig and fl['F_CONTIGUOUS']
     if not (c_contig or f_contig):
         return None, None, False
-    return n, offsets, True
+    return n, tuple(offsets), True
 
 def check_args(args, collapse=False, broadcast=False):
     """
@@ -177,10 +177,10 @@ def check_args(args, collapse=False, broadcast=False):
             strs = [list(str) if str is not None else str for str in strs]
         collapse = True
 
-    if collapse:
+    if nd > 1 and collapse:
         # remove dimensions that are of size 1
         for i in range(nd-1, -1, -1):
-            if dims[i] == 1:
+            if nd > 1 and dims[i] == 1:
                 del dims[i]
                 for str in strs:
                     if str is not None:


### PR DESCRIPTION
Hi, the first two commits fix bugs in check_args that are described in the commit messages. The third commit is just a suggestion: this function computes information that never gets used in the contiguous case (which is presumably also the most common), so a simplified version check_contig only computes what is needed, and is faster.