### PR TITLE
Use nvrtc, instead of nvcc, to compile CUDA to PTX.

### DIFF
--- a/pygpu/elemwise.py
+++ b/pygpu/elemwise.py
@@ -42,8 +42,10 @@ KERNEL void ${name}(const unsigned int n
 % endfor
 
   for (i = idx; i < n; i += numThreads) {
+% if nd > 0:
     int ii = i;
     int pos;
+% endif
 % for arg in arguments:
     % if arg.isarray():
         GLOBAL_MEM char *${arg.name}_p = (GLOBAL_MEM char *)${arg.name}_data;
@@ -102,8 +104,10 @@ KERNEL void ${name}(
 % endfor
 
   for (i = idx; i < ${n}; i += numThreads) {
+% if nd > 0:
     int ii = i;
     int pos;
+% endif
 % for arg in arguments:
     % if arg.isarray():
         GLOBAL_MEM char *${arg.name}_p = (GLOBAL_MEM char *)${arg.name}_data;
@@ -194,8 +198,10 @@ KERNEL void ${name}(
 % endfor
 
   for (i = idx; i < ${n}; i += numThreads) {
+% if nd > 0:
     int ii = i;
     int pos;
+% endif
 % for arg in arguments:
     % if arg.isarray():
         GLOBAL_MEM char *${arg.name}_p = (GLOBAL_MEM char *)${arg.name}_data;

--- a/pygpu/elemwise.py
+++ b/pygpu/elemwise.py
@@ -13,16 +13,16 @@ __all__ = ['ElemwiseKernel', 'elemwise1', 'elemwise2', 'ielemwise2', 'compare']
 basic_kernel = Template("""
 ${preamble}
 
-KERNEL void ${name}(const unsigned int n
+KERNEL void ${name}(const ga_size n
 % for d in range(nd):
-                    , const unsigned int dim${d}
+                    , const ga_size dim${d}
 % endfor
 % for arg in arguments:
     % if arg.isarray():
                     , ${arg.decltype()} ${arg.name}_data
-                    , const unsigned int ${arg.name}_offset
+                    , const ga_size ${arg.name}_offset
         % for d in range(nd):
-                    , const int ${arg.name}_str_${d}
+                    , const ga_ssize ${arg.name}_str_${d}
         % endfor
     % else:
                     , ${arg.decltype()} ${arg.name}
@@ -82,9 +82,9 @@ KERNEL void ${name}(
 % for arg in arguments:
     % if arg.isarray():
                     ${arg.decltype()} ${arg.name}_data,
-                    const unsigned int ${arg.name}_offset${'' if nd == 0 and loop.last else ','}
+                    const ga_size ${arg.name}_offset${'' if nd == 0 and loop.last else ','}
         % for d in range(nd):
-                    const int ${arg.name}_str_${d}${'' if (loop.last and loop.parent.last) else ','}
+                    const ga_ssize ${arg.name}_str_${d}${'' if (loop.last and loop.parent.last) else ','}
         % endfor
     % else:
                     ${arg.decltype()} ${arg.name}${',' if not loop.last else ''}
@@ -140,11 +140,11 @@ KERNEL void ${name}(
 contiguous_kernel = Template("""
 ${preamble}
 
-KERNEL void ${name}(const unsigned int n
+KERNEL void ${name}(const ga_size n
 % for arg in arguments:
                     , ${arg.decltype()} ${arg.name}
   % if arg.isarray():
-                    , const unsigned int ${arg.name}_offset
+                    , const ga_size ${arg.name}_offset
   % endif
 % endfor
 ) {
@@ -318,11 +318,11 @@ class ElemwiseKernel(object):
 
     def argspec_contig(self):
         spec = []
-        spec.append('uint32')
+        spec.append(str(numpy.dtype('uintp')))
         for i, arg in enumerate(self.arguments):
             spec.append(arg.spec())
             if arg.isarray():
-                spec.append('uint32')
+                spec.append(str(numpy.dtype('uintp')))
         return spec
 
     def render_basic(self, nd, name="elemk"):
@@ -350,13 +350,13 @@ class ElemwiseKernel(object):
 
     def argspec_basic(self, nd):
         spec = []
-        spec.append('uint32')
-        spec.extend('uint32' for _ in range(nd))
+        spec.append(str(numpy.dtype('uintp')))
+        spec.extend(str(numpy.dtype('uintp')) for _ in range(nd))
         for i, arg in enumerate(self.arguments):
             spec.append(arg.spec())
             if arg.isarray():
-                spec.append('uint32')
-                spec.extend('int32' for _ in range(nd))
+                spec.append(str(numpy.dtype('uintp')))
+                spec.extend(str(numpy.dtype('intp')) for _ in range(nd))
         return spec
 
     def get_basic(self, args, n, nd, dims, strs, offsets):
@@ -393,8 +393,8 @@ class ElemwiseKernel(object):
         for i, arg in enumerate(self.arguments):
             spec.append(arg.spec())
             if arg.isarray():
-                spec.append('uint32')
-                spec.extend('int32' for _ in range(nd))
+                spec.append(str(numpy.dtype('uintp')))
+                spec.extend(str(numpy.dtype('intp')) for _ in range(nd))
         return spec
 
     def get_dimspec(self, args, n, nd, dims, strs, offsets):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,24 @@ if (CUDA_FOUND)
     SET(CUDADRV_LIBRARY ${CUDA_CUDA_LIBRARY})
     SET(CUDADRV_INCLUDE ${CUDA_TOOLKIT_INCLUDE})
   endif()
+  find_library(CUDA_NVRTC_LIBRARY
+    NAMES nvrtc
+    PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
+    PATH_SUFFIXES lib lib64
+    NO_DEFAULT_PATH
+    )
+  if(CUDA_NVRTC_LIBRARY)
+    add_definitions(-DWITH_NVRTC)
+    find_program(CUDA_PTXAS_EXECUTABLE
+      NAMES ptxas
+      PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
+      PATH_SUFFIXES bin bin64
+      NO_DEFAULT_PATH
+      )
+    if (CUDA_PTXAS_EXECUTABLE)
+      add_definitions(-DPTXAS_BIN="${CUDA_PTXAS_EXECUTABLE}")
+    endif()
+  endif()
 
   set(GPUARRAY_SRC ${GPUARRAY_SRC} gpuarray_buffer_cuda.c)
   add_definitions(-DNVCC_BIN="${CUDA_NVCC_EXECUTABLE}" -DWITH_CUDA)
@@ -119,8 +137,13 @@ endif()
 add_library(gpuarray-static STATIC ${GPUARRAY_SRC})
 
 if(CUDA_FOUND)
-  target_link_libraries(gpuarray ${CUDADRV_LIBRARY} ${CUDA_CUBLAS_LIBRARIES})
-  target_link_libraries(gpuarray-static ${CUDADRV_LIBRARY} ${CUDA_CUBLAS_LIBRARY})
+  if(CUDA_NVRTC_LIBRARY)
+    target_link_libraries(gpuarray ${CUDADRV_LIBRARY} ${CUDA_CUBLAS_LIBRARIES} ${CUDA_NVRTC_LIBRARY})
+    target_link_libraries(gpuarray-static ${CUDADRV_LIBRARY} ${CUDA_CUBLAS_LIBRARY} ${CUDA_NVRTC_LIBRARY})
+  else()
+    target_link_libraries(gpuarray ${CUDADRV_LIBRARY} ${CUDA_CUBLAS_LIBRARIES})
+    target_link_libraries(gpuarray-static ${CUDADRV_LIBRARY} ${CUDA_CUBLAS_LIBRARY})
+  endif()
 endif()
 
 if(OPENCL_FOUND)

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -199,7 +199,9 @@ static const char CUDA_PREAMBLE[] =
     "#define LOCAL_MEM __shared__\n"
     "#define LOCAL_MEM_ARG /* empty */\n"
     "#define REQD_WG_SIZE(X,Y,Z) __launch_bounds__(X*Y, Z)\n"
+    "#ifndef __CUDACC_RTC__\n"
     "#include <math_constants.h>\n"
+    "#endif\n"
     "#ifdef NAN\n"
     "#undef NAN\n"
     "#endif\n"
@@ -225,11 +227,6 @@ static const char CUDA_PREAMBLE[] =
     "typedef unsigned int uint32_t;\n"
     "typedef signed long long int64_t;\n"
     "typedef unsigned long long uint64_t;\n"
-    "#ifndef __intptr_t_defined\n"
-    "typedef long int                intptr_t;\n"
-    "#define __intptr_t_defined\n"
-    "#endif\n"
-    "typedef unsigned long int uintptr_t;\n"
     "#else\n"
     "#ifdef _MSC_VER\n"
     "#define signed __int8 int8_t\n"
@@ -257,7 +254,11 @@ static const char CUDA_PREAMBLE[] =
     "#define ga_double double\n"
     "#define ga_half uint16_t\n"
     "#define ga_size size_t\n"
-    "#define ga_ssize ssize_t\n";
+    "#ifdef __CUDACC_RTC__\n"
+    "#define ga_ssize int64_t\n"
+    "#else\n"
+    "#define ga_ssize ssize_t\n"
+    "#endif\n";
 
 /* XXX: add complex, quads, longlong */
 /* XXX: add vector types */

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -3,6 +3,9 @@
 #include "private.h"
 #include "private_cuda.h"
 
+#ifdef WITH_NVRTC
+#include <nvrtc.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -59,7 +62,7 @@ static int cuda_property(void *, gpudata *, gpukernel *, int, void *);
 #define val_free(v) cuda_freekernel(*v);
 #include "cache_extcopy.h"
 
-static int detect_arch(char *ret);
+static int detect_arch(const char *prefix, char *ret);
 
 void *cuda_make_ctx(CUcontext ctx, int flags) {
   int64_t v = 0;
@@ -74,7 +77,7 @@ void *cuda_make_ctx(CUcontext ctx, int flags) {
   res->blas_handle = NULL;
   res->refcnt = 1;
   res->flags = flags;
-  if (detect_arch(res->bin_id)) {
+  if (detect_arch("sm_", res->bin_id)) {
     free(res);
     return NULL;
   }
@@ -213,6 +216,21 @@ static const char CUDA_PREAMBLE[] =
     "#define GDIM_0 gridDim.x\n"
     "#define GDIM_1 gridDim.y\n"
     "#define GDIM_2 gridDim.z\n"
+    "#ifdef __CUDACC_RTC__\n"
+    "typedef signed char int8_t;\n"
+    "typedef unsigned char uint8_t;\n"
+    "typedef signed short int16_t;\n"
+    "typedef unsigned short uint16_t;\n"
+    "typedef signed int int32_t;\n"
+    "typedef unsigned int uint32_t;\n"
+    "typedef signed long long int64_t;\n"
+    "typedef unsigned long long uint64_t;\n"
+    "#ifndef __intptr_t_defined\n"
+    "typedef long int                intptr_t;\n"
+    "#define __intptr_t_defined\n"
+    "#endif\n"
+    "typedef unsigned long int uintptr_t;\n"
+    "#else\n"
     "#ifdef _MSC_VER\n"
     "#define signed __int8 int8_t\n"
     "#define unsigned __int8 uint8_t\n"
@@ -224,6 +242,7 @@ static const char CUDA_PREAMBLE[] =
     "#define unsigned __int64 uint64_t\n"
     "#else\n"
     "#include <stdint.h>\n"
+    "#endif\n"
     "#endif\n"
     "#define ga_bool uint8_t\n"
     "#define ga_byte int8_t\n"
@@ -564,17 +583,18 @@ static CUresult get_cc(CUdevice dev, int *maj, int *min) {
 #endif
 }
 
-static int detect_arch(char *ret) {
+static int detect_arch(const char *prefix, char *ret) {
     CUdevice dev;
     int major, minor;
     int res;
+    size_t sz = strlen(prefix) + 3;
     CUresult err;
     err = cuCtxGetDevice(&dev);
     if (err != CUDA_SUCCESS) return GA_IMPL_ERROR;
     err = get_cc(dev, &major, &minor);
     if (err != CUDA_SUCCESS) return GA_IMPL_ERROR;
-    res = snprintf(ret, 6, "sm_%d%d", major, minor);
-    if (res == -1 || res > 6) return GA_UNSUPPORTED_ERROR;
+    res = snprintf(ret, sz, "%s%d%d", prefix, major, minor);
+    if (res == -1 || res > sz) return GA_UNSUPPORTED_ERROR;
     return GA_NO_ERROR;
 }
 
@@ -598,7 +618,7 @@ static void *call_compiler_impl(const char *src, size_t len, size_t *bin_len,
     char *buf;
     int res;
 
-    res = detect_arch(arch_arg);
+    res = detect_arch("sm_", arch_arg);
     if (res != GA_NO_ERROR) FAIL(NULL, res);
 
     for (i = 0; i < sizeof(TMP_VAR_NAMES)/sizeof(TMP_VAR_NAMES[0]); i++) {
@@ -622,7 +642,59 @@ static void *call_compiler_impl(const char *src, size_t len, size_t *bin_len,
     strlcpy(outbuf, namebuf, sizeof(outbuf));
     strlcat(outbuf, ".cubin", sizeof(outbuf));
 
+    /* Get the PTX using nvrtc, which is faster than using nvcc. */
+#ifdef WITH_NVRTC
+    {
+      char compute_arch_arg[11]; /* Must be at least 11, see detect_arch() */
+#ifdef DEBUG
+      const char *nvrtc_args[] = {"-G", "-arch", compute_arch_arg};
+      const size_t nvrtc_num_args = 3;
+#else
+      const char *nvrtc_args[] = {"-arch", compute_arch_arg};
+      const size_t nvrtc_num_args = 2;
+#endif
+      char *ptx;
+      size_t ptx_len;
+      char cubuf[PATH_MAX];
+      res = detect_arch("compute_", compute_arch_arg);
+      if (res != GA_NO_ERROR) FAIL(NULL, res);
+      strlcpy(cubuf, namebuf, sizeof(cubuf));
+      strlcat(cubuf, ".cu", sizeof(cubuf));
+      nvrtcProgram prog;
+      if (nvrtcCreateProgram(&prog, src, cubuf, 0, NULL, NULL) != NVRTC_SUCCESS) {
+        FAIL(NULL, GA_IMPL_ERROR);
+      }
+      if (nvrtcCompileProgram(prog, nvrtc_num_args, nvrtc_args) != NVRTC_SUCCESS) {
+        char *log;
+        size_t log_len;
+        nvrtcGetProgramLogSize(prog, &log_len);
+        log = (char *)malloc(log_len);
+        if (log == NULL) FAIL(NULL, GA_MEMORY_ERROR);
+        nvrtcGetProgramLog(prog, log);
+        printf("%s\n", log);
+        free(log);
+        nvrtcDestroyProgram(&prog);
+        FAIL(NULL, GA_IMPL_ERROR);
+      }
+      if (nvrtcGetPTXSize(prog, &ptx_len) != NVRTC_SUCCESS) {
+        nvrtcDestroyProgram(&prog);
+        FAIL(NULL, GA_IMPL_ERROR);
+      }
+      ptx = (char *)malloc(ptx_len);
+      if (ptx == NULL) FAIL(NULL, GA_MEMORY_ERROR);
+      if (nvrtcGetPTX(prog, ptx) != NVRTC_SUCCESS) {
+        free(ptx);
+        nvrtcDestroyProgram(&prog);
+        FAIL(NULL, GA_IMPL_ERROR);
+      }
+      nvrtcDestroyProgram(&prog);
+
+      s = write(fd, ptx, ptx_len);
+      free(ptx);
+    }
+#else
     s = write(fd, src, len);
+#endif
     close(fd);
     /* fd is not non-blocking; should have complete write */
     if (s == -1) {
@@ -630,6 +702,16 @@ static void *call_compiler_impl(const char *src, size_t len, size_t *bin_len,
         FAIL(NULL, GA_SYS_ERROR);
     }
 
+#ifdef WITH_NVRTC
+    /* This block executes ptxas on the written-out file */
+#ifdef DEBUG
+#define PTXAS_ARGS PTXAS_BIN, "--device-debug", "-arch", arch_arg, \
+      namebuf, "-o", outbuf
+#else
+#define PTXAS_ARGS PTXAS_BIN, "-arch", arch_arg, \
+      namebuf, "-o", outbuf
+#endif
+#else
     /* This block executes nvcc on the written-out file */
 #ifdef DEBUG
 #define NVCC_ARGS NVCC_BIN, "-g", "-G", "-arch", arch_arg, "-x", "cu", \
@@ -638,15 +720,24 @@ static void *call_compiler_impl(const char *src, size_t len, size_t *bin_len,
 #define NVCC_ARGS NVCC_BIN, "-arch", arch_arg, "-x", "cu", \
       "--cubin", namebuf, "-o", outbuf
 #endif
+#endif
 #ifdef _WIN32
+#ifdef WITH_NVRTC
+    sys_err = _spawnl(_P_WAIT, PTXAS_BIN, PTXAS_ARGS, NULL);
+#else
     sys_err = _spawnl(_P_WAIT, NVCC_BIN, NVCC_ARGS, NULL);
+#endif
     unlink(namebuf);
     if (sys_err == -1) FAIL(NULL, GA_SYS_ERROR);
     if (sys_err != 0) FAIL(NULL, GA_RUN_ERROR);
 #else
     p = fork();
     if (p == 0) {
+#ifdef WITH_NVRTC
+        execl(PTXAS_BIN, PTXAS_ARGS, NULL);
+#else
         execl(NVCC_BIN, NVCC_ARGS, NULL);
+#endif
         exit(1);
     }
     if (p == -1) {
@@ -655,7 +746,8 @@ static void *call_compiler_impl(const char *src, size_t len, size_t *bin_len,
     }
 
     /* We need to wait until after the waitpid for the unlink because otherwise
-       we might delete the input file before nvcc is finished with it. */
+       we might delete the input file before ptxas or nvcc is finished with
+       it. */
     if (waitpid(p, &sys_err, 0) == -1) {
         unlink(namebuf);
         unlink(outbuf);
@@ -800,7 +892,7 @@ static gpukernel *cuda_newkernel(void *c, unsigned int count,
 
       if (lengths == NULL) {
         for (i = 0; i < count; i++)
-        strb_appends(&sb, strings[i]);
+          strb_appends(&sb, strings[i]);
       } else {
         for (i = 0; i < count; i++) {
           if (lengths[i] == 0)
@@ -810,7 +902,11 @@ static gpukernel *cuda_newkernel(void *c, unsigned int count,
         }
       }
 
+#ifdef WITH_NVRTC
+      if (!binary_mode) strb_append0(&sb);
+#else
       if (ptx_mode) strb_append0(&sb);
+#endif
 
       if (strb_error(&sb)) {
         strb_clear(&sb);
@@ -1133,7 +1229,7 @@ static inline int gen_extcopy_kernel(const cache_key_t *a,
     out_ld_t = out_t;
   rmod = get_rmod(a->itype, a->otype);
   if (in_t == NULL || out_t == NULL) return GA_DEVSUP_ERROR;
-  res = detect_arch(arch);
+  res = detect_arch("sm_", arch);
   if (res != GA_NO_ERROR) return res;
 
   strb_appendf(&sb, ELEM_HEADER_PTX, arch, bits, bits, bits,

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -52,7 +52,7 @@ typedef struct _cuda_context {
   void *blas_handle;
   gpudata *errbuf;
   cache *extcopy_cache;
-  char bin_id[8];
+  char bin_id[13];
   unsigned int refcnt;
   int flags;
 } cuda_context;


### PR DESCRIPTION
These commits allow libgpuarray to use nvrtc (http://docs.nvidia.com/cuda/nvrtc/index.html) to compile CUDA source code to PTX, instead of nvcc, if nvrtc is found on the system.

It should reduce compilation overhead associated with nvcc subprocess creation, nvcc intermediate file disk I/O, etc.

If nvrtc is not found on the system, nvcc is used as before.