### PR TITLE
Add missing SkipTest import

### DIFF
--- a/pygpu/tests/test_blas.py
+++ b/pygpu/tests/test_blas.py
@@ -1,4 +1,5 @@
 import numpy
+from nose.plugins.skip import SkipTest
 
 from .support import (guard_devsup, gen_gpuarray, context)
 


### PR DESCRIPTION
This is encountered when scipy is not present.

#83