### PR TITLE
Enable async read/write ops on a separate stream.

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -182,7 +182,7 @@ static gpudata *new_gpudata(cuda_context *ctx, CUdeviceptr ptr, size_t size) {
 
   ctx->err = cuEventCreate(&res->wev, fl);
   if (ctx->err != CUDA_SUCCESS) {
-    cuEventDestroy(&res->rev);
+    cuEventDestroy(res->rev);
     cuda_exit(ctx);
     free(res);
     return NULL;
@@ -1708,7 +1708,7 @@ static gpudata *cuda_transfer(gpudata *src, size_t offset, size_t sz,
   }
 
   cuda_records(dst, CUDA_WAIT_WRITE, dst_ctx->mem_s);
-  cuda_record(src, CUDA_WAIT_READ, dst_ctx->mem_s);
+  cuda_records(src, CUDA_WAIT_READ, dst_ctx->mem_s);
 
   cuda_exit(ctx);
   return dst;

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -50,6 +50,7 @@ typedef struct _cuda_context {
   CUcontext ctx;
   CUresult err;
   CUstream s;
+  CUstream mem_s;
   void *blas_handle;
   gpudata *errbuf;
   cache *extcopy_cache;

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -90,12 +90,13 @@ GPUARRAY_LOCAL void cuda_exit(cuda_context *ctx);
 
 struct _gpudata {
   CUdeviceptr ptr;
-  CUevent ev;
+  CUevent rev;
+  CUevent wev;
   size_t sz;
   cuda_context *ctx;
+  gpudata *next;
   int flags;
   unsigned int refcnt;
-  gpudata *next;
 #ifdef DEBUG
   char tag[8];
 #endif


### PR DESCRIPTION
Tests have assured me that we don't need to wait on the host side
after a transfer in either direction to play with host memory.  The
only required synchronizations are with the device-side operations
which we perform correctly here.

This supersedes #99 