### PR TITLE
Create a primary context for better compat with the runtime API.

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,9 +4,9 @@ Installation
 The library is routinely tested on OS X and linux and, less
 frequently, on Windows.  The OS most frequently tested are:
 
- - Mac OS X 10.10
- - Fedora Core 14
- - Ubuntu 12.04
+ - Debian 6
+ - Ubuntu 14.04
+ - Mac OS X 10.11
  - Windows 7
 
 It should also work on any decently recent OS not listed here. If you
@@ -38,8 +38,6 @@ Requirements
 Download
 --------
 
-The code is currently in a github repo branch. It will be moved. To
-get it:
 ::
 
   git clone https://github.com/Theano/libgpuarray.git
@@ -150,7 +148,9 @@ Since there is no standard install location on Windows, there is no
 install step.  It is up to you to copy the headers and libraries to an
 appropriate place.
 
-If you don't have Visual Studio installed, you can get the free Express version from `here <http://www.visualstudio.com/>`_ in the downloads section (select the "for Windows" edition).
+If you don't have Visual Studio installed, you can get the free
+Express version from `here <http://www.visualstudio.com/>`_ in the
+downloads section (select the "for Windows" edition).
 
 .. warning::
    While you may get the library to compile using cygwin, this is not
@@ -182,7 +182,8 @@ If you get an error message similar to this one:
 This means either you don't have check installed or it wasn't found by
 the cmake detection script.
 
-To run the python tests, install pygpu, then move outside its directory and run this command:
+To run the python tests, install pygpu, then move outside its
+directory and run this command:
 
 ::
 

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -102,6 +102,9 @@ static void deallocate(gpudata *);
 static void cuda_free_ctx(cuda_context *ctx) {
   gpuarray_blas_ops *blas_ops;
   gpudata *next, *curr;
+#ifdef CUDA_VERSION >= 7000
+  CUdevice dev;
+#endif
 
   ASSERT_CTX(ctx);
   ctx->refcnt--;
@@ -124,8 +127,16 @@ static void cuda_free_ctx(cuda_context *ctx) {
       deallocate(curr);
     }
 
-    if (!(ctx->flags & DONTFREE))
-      cuDevicePrimaryCtxRelease(ctx->ctx);
+    if (!(ctx->flags & DONTFREE)) {
+#if CUDA_VERSION < 7000
+      cuCtxDestroy(ctx->ctx);
+#else
+      cuCtxPushCurrent(ctx->ctx);
+      cuCtxGetDevice(&dev);
+      cuCtxPopCurrent(NULL);
+      cuDevicePrimaryCtxRelease(dev);
+#endif
+    }
     cache_destroy(ctx->extcopy_cache);
     CLEAR(ctx);
     free(ctx);
@@ -262,8 +273,10 @@ static void *do_init(CUdevice dev, int flags, int *ret) {
     cuda_context *res;
     CUcontext ctx;
     unsigned int fl = CU_CTX_SCHED_AUTO;
+#if CUDA_VERSION >= 7000
     unsigned int cur_fl;
     int act;
+#endif
     int i;
 
     CHKFAIL(NULL);
@@ -275,6 +288,10 @@ static void *do_init(CUdevice dev, int flags, int *ret) {
     CHKFAIL(NULL);
     if (i != 1)
       FAIL(NULL, GA_UNSUPPORTED_ERROR);
+#if CUDA_VERSION < 7000
+    err = cuCtxCreate(&ctx, fl, dev);
+    CHKFAIL(NULL);
+#else
     err = cuDevicePrimaryCtxGetState(dev, &cur_fl, &act);
     CHKFAIL(NULL);
     if (act == 1 && (cur_fl & fl) != fl)
@@ -283,9 +300,14 @@ static void *do_init(CUdevice dev, int flags, int *ret) {
     CHKFAIL(NULL);
     err = cuDevicePrimaryCtxRetain(&ctx, dev);
     CHKFAIL(NULL);
+#endif
     res = cuda_make_ctx(ctx, 0);
     if (res == NULL) {
-      cuDevicePrimaryCtxRelease(ctx);
+#if CUDA_VERSION < 7000
+      cuCtxDestroy(ctx);
+#else
+      cuDevicePrimaryCtxRelease(dev);
+#endif
       FAIL(NULL, GA_IMPL_ERROR);
     }
     res->flags |= flags;

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -102,7 +102,7 @@ static void deallocate(gpudata *);
 static void cuda_free_ctx(cuda_context *ctx) {
   gpuarray_blas_ops *blas_ops;
   gpudata *next, *curr;
-#ifdef CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000
   CUdevice dev;
 #endif
 
@@ -299,6 +299,8 @@ static void *do_init(CUdevice dev, int flags, int *ret) {
     err = cuDevicePrimaryCtxSetFlags(dev, fl);
     CHKFAIL(NULL);
     err = cuDevicePrimaryCtxRetain(&ctx, dev);
+    CHKFAIL(NULL);
+    err = cuCtxPushCurrent(ctx);
     CHKFAIL(NULL);
 #endif
     res = cuda_make_ctx(ctx, 0);


### PR DESCRIPTION
This functionality doesn't exist in 6.5 so we keep the old behavior for that version in order to not drop support right now.