### PR TITLE
C elemwise generator

### DIFF
--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -623,6 +623,8 @@ def init(dev, sched='default', disable_alloc_cache=False):
     are no gaps in the valid numbers.
     """
     cdef int flags = 0
+    if gpuarray_api_major != -9999 or gpuarray_api_minor < 0:
+        raise RuntimeError("Pygpu was compiled for a different version of the api, recompile it to avoid problems.")
     if sched == 'single':
         flags |= GA_CTX_SINGLE_THREAD
     elif sched == 'multi':

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ gpuarray_array.c
 gpuarray_array_blas.c
 gpuarray_kernel.c
 gpuarray_extension.c
+gpuarray_elemwise.c
 )
 
 check_function_exists(strlcat HAVE_STRL)
@@ -152,6 +153,7 @@ SET(headers
   gpuarray/buffer.h
   gpuarray/buffer_blas.h
   gpuarray/config.h
+  gpuarray/elemwise.h
   gpuarray/error.h
   gpuarray/extension.h
   gpuarray/ext_cuda.h

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -334,14 +334,32 @@ typedef struct _gpuarray_buffer_ops {
   void (*kernel_release)(gpukernel *k);
 
   /**
+   * Set kernel argument.
+   *
+   * Buffer arguments will not be retained and it is the
+   * responsability of the caller to ensure that the value is still
+   * valid whenever a call is made.
+   *
+   * \param k kernel
+   * \param i argument index (starting at 0)
+   * \param a pointer to argument
+   *
+   * \returns GA_NO_ERROR or an error code if an error occurred.
+   */
+  int (*kernel_setarg)(gpukernel *k, unsigned int i, void *a);
+
+  /**
    * Call a kernel.
+   *
+   * If args is NULL, it will be assumed that the arguments have
+   * previously been set with kernel_setarg().
    *
    * \param k kernel
    * \param n number of dimensions of grid/block
    * \param bs block sizes for this call (also known as local size)
    * \param gs grid sizes for this call (also known as global size)
    * \param shared amount of dynamic shared memory to reserve
-   * \param args table of pointers to each argument.
+   * \param args table of pointers to each argument (optional).
    *
    * \returns GA_NO_ERROR or an error code if an error occurred.
    */

--- a/src/gpuarray/elemwise.h
+++ b/src/gpuarray/elemwise.h
@@ -72,16 +72,14 @@ typedef struct _gpuelemwise_arg {
 #define GE_SCALAR      0x0001
 
   /**
-   * Disable indexing for this argument on dimensions of size 1.
-   * Requires dims.
+   * Array is read from in the expression.
    */
-#define GE_NOINDEX1    0x0002
+#define GE_READ        0x0002
 
   /**
-   * Disable specialization on dimensions for this argument even if
-   * dims is provided.
+   * Array is written to in the expression.
    */
-#define GE_NODIMSPEC   0x0004
+#define GE_WRITE       0x0004
 
 /**
  * }@

--- a/src/gpuarray/elemwise.h
+++ b/src/gpuarray/elemwise.h
@@ -1,0 +1,104 @@
+#ifndef GPUARRAY_ELEMWISE_H
+#define GPUARRAY_ELEMWISE_H
+/** \file elemwise.h
+ *  \brief Custom elementwise operations generator.
+ */
+
+#include <gpuarray/buffer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef CONFUSE_EMACS
+}
+#endif
+
+struct _GpuElemwise;
+
+/**
+ * Elementwise genearator structure.
+ *
+ * The contents are private.
+ */
+typedef struct _GpuElemwise GpuElemwise;
+
+/**
+ * Argument information structure for GpuElemwise.
+ */
+typedef struct _gpuelemwise_arg {
+  /**
+   * Dimension sizes of argument, optional (can be NULL).
+   */
+  size_t *dims;
+
+  /**
+   * Strides of argument, optional (can be NULL).
+   */
+  ssize_t *strs;
+
+  /**
+   * Name of this argument in the associated expression, mandatory.
+   */
+  const char *name;
+
+  /**
+   * Number of dimensions of argument, mandatory.
+   */
+  unsigned int nd;
+
+  /**
+   * Type of argument, mandatory (not GA_BUFFER, the content dtype)
+   */
+  int typecode;
+
+  /**
+   * Padding, do not use (must be 0).
+   */
+  unsigned int reserved;
+
+  /**
+   * Argument flags, mandatory (see \ref eflags).
+   */
+  int flags;
+
+/**
+ * \defgroup eflags GpuElemwise argument flags
+ * @{
+ */
+
+  /**
+   * Argument is a scalar passed from the CPU, requires nd == 0.
+   */
+#define GE_SCALAR      0x0001
+
+  /**
+   * Disable indexing for this argument on dimensions of size 1.
+   * Requires dims.
+   */
+#define GE_NOINDEX1    0x0002
+
+  /**
+   * Disable specialization on dimensions for this argument even if
+   * dims is provided.
+   */
+#define GE_NODIMSPEC   0x0004
+
+/**
+ * }@
+ */
+
+} gpuelemwise_arg;
+
+GPUARRAY_PUBLIC GpuElemwise *GpuElemwise_new(const gpuarray_buffer_ops *ops,
+                                             void * ctx,
+                                             const char *preamble,
+                                             const char *expr,
+                                             unsigned int n,
+                                             gpuelemwise_arg *args, int flags);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/gpuarray/elemwise.h
+++ b/src/gpuarray/elemwise.h
@@ -96,6 +96,12 @@ GPUARRAY_PUBLIC GpuElemwise *GpuElemwise_new(const gpuarray_buffer_ops *ops,
                                              unsigned int n,
                                              gpuelemwise_arg *args, int flags);
 
+GPUARRAY_PUBLIC void GpuElemwise_free(GpuElemwise *ge);
+
+GPUARRAY_PUBLIC int GpuElemwise_call(GpuElemwise *ge, void **args, int flags);
+
+#define GE_BROADCAST   0x0100
+#define GE_NOCOLLAPSE  0x0200
 
 #ifdef __cplusplus
 }

--- a/src/gpuarray/elemwise.h
+++ b/src/gpuarray/elemwise.h
@@ -27,34 +27,14 @@ typedef struct _GpuElemwise GpuElemwise;
  */
 typedef struct _gpuelemwise_arg {
   /**
-   * Dimension sizes of argument, optional (can be NULL).
-   */
-  size_t *dims;
-
-  /**
-   * Strides of argument, optional (can be NULL).
-   */
-  ssize_t *strs;
-
-  /**
    * Name of this argument in the associated expression, mandatory.
    */
   const char *name;
 
   /**
-   * Number of dimensions of argument, mandatory.
-   */
-  unsigned int nd;
-
-  /**
    * Type of argument, mandatory (not GA_BUFFER, the content dtype)
    */
   int typecode;
-
-  /**
-   * Padding, do not use (must be 0).
-   */
-  unsigned int reserved;
 
   /**
    * Argument flags, mandatory (see \ref eflags).
@@ -92,7 +72,9 @@ GPUARRAY_PUBLIC GpuElemwise *GpuElemwise_new(const gpuarray_buffer_ops *ops,
                                              const char *preamble,
                                              const char *expr,
                                              unsigned int n,
-                                             gpuelemwise_arg *args, int flags);
+                                             gpuelemwise_arg *args,
+                                             unsigned int nd,
+                                             int flags);
 
 GPUARRAY_PUBLIC void GpuElemwise_free(GpuElemwise *ge);
 

--- a/src/gpuarray/elemwise.h
+++ b/src/gpuarray/elemwise.h
@@ -16,7 +16,7 @@ extern "C" {
 struct _GpuElemwise;
 
 /**
- * Elementwise genearator structure.
+ * Elementwise generator structure.
  *
  * The contents are private.
  */

--- a/src/gpuarray/kernel.h
+++ b/src/gpuarray/kernel.h
@@ -76,6 +76,9 @@ GPUARRAY_PUBLIC void GpuKernel_clear(GpuKernel *k);
  */
 GPUARRAY_PUBLIC void *GpuKernel_context(GpuKernel *k);
 
+
+GPUARRAY_PUBLIC int GpuKernel_setarg(GpuKernel *k, unsigned int i, void *val);
+
 /**
  * Do a scheduling of local and global size for a kernel.
  *

--- a/src/gpuarray/util.h
+++ b/src/gpuarray/util.h
@@ -75,6 +75,8 @@ GPUARRAY_PUBLIC size_t gpuarray_get_elsize(int typecode);
  */
 GPUARRAY_PUBLIC int gpuarray_type_flags(int init, ...);
 
+GPUARRAY_PUBLIC int gpuarray_type_flagsa(unsigned int n, gpuarray_arg *arg);
+
 /**
  * Perform dimension collapsing on the specified arguments.
  *
@@ -97,6 +99,7 @@ GPUARRAY_PUBLIC int gpuarray_type_flags(int init, ...);
 GPUARRAY_PUBLIC void gpuarray_elemwise_collapse(unsigned int n,
                                                 unsigned int *nd,
                                                 size_t *dim, ssize_t **strs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gpuarray/util.h
+++ b/src/gpuarray/util.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include <gpuarray/config.h>
+#include <gpuarray/elemwise.h>
 #include <gpuarray/types.h>
 
 extern GPUARRAY_PUBLIC const int gpuarray_api_major;
@@ -75,7 +76,7 @@ GPUARRAY_PUBLIC size_t gpuarray_get_elsize(int typecode);
  */
 GPUARRAY_PUBLIC int gpuarray_type_flags(int init, ...);
 
-GPUARRAY_PUBLIC int gpuarray_type_flagsa(unsigned int n, gpuarray_arg *arg);
+GPUARRAY_PUBLIC int gpuarray_type_flagsa(unsigned int n, gpuelemwise_arg *arg);
 
 /**
  * Perform dimension collapsing on the specified arguments.

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1324,15 +1324,15 @@ static int cuda_callkernel(gpukernel *k, unsigned int n,
     ASSERT_KER(k);
     cuda_enter(ctx);
 
+    if (args == NULL)
+      args = k->args;
+
     for (i = 0; i < k->argcount; i++) {
       if (k->types[i] == GA_BUFFER) {
 	/* We don't have any better info for now */
 	cuda_wait((gpudata *)args[i], CUDA_WAIT_READ|CUDA_WAIT_WRITE);
       }
     }
-
-    if (args == NULL)
-      args = k->args;
 
     switch (n) {
     case 1:

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1308,6 +1308,13 @@ static void cuda_freekernel(gpukernel *k) {
   _cuda_freekernel(k);
 }
 
+static int cuda_kernelsetarg(gpukernel *k, unsigned int i, void *arg) {
+  if (i >= k->argcount)
+    return GA_VALUE_ERROR;
+  k->args[i] = arg;
+  return GA_NO_ERROR;
+}
+
 static int cuda_callkernel(gpukernel *k, unsigned int n,
                            const size_t *bs, const size_t *gs,
                            size_t shared, void **args) {
@@ -1323,6 +1330,9 @@ static int cuda_callkernel(gpukernel *k, unsigned int n,
 	cuda_wait((gpudata *)args[i], CUDA_WAIT_READ|CUDA_WAIT_WRITE);
       }
     }
+
+    if (args == NULL)
+      args = k->args;
 
     switch (n) {
     case 1:
@@ -1972,6 +1982,7 @@ const gpuarray_buffer_ops cuda_ops = {cuda_init,
                                       cuda_newkernel,
                                       cuda_retainkernel,
                                       cuda_freekernel,
+                                      cuda_kernelsetarg,
                                       cuda_callkernel,
                                       cuda_kernelbin,
                                       cuda_sync,

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1217,9 +1217,8 @@ static gpukernel *cuda_newkernel(void *c, unsigned int count,
           return NULL;
         }
         if (compile_cache == NULL)
-          compile_cache = cache_twoq(16, 16, 16, 8, src_eq, src_hash, src_free,
-                                     bin_free);
-
+          compile_cache = cache_twoq(64, 128, 64, 8, src_eq, src_hash,
+				     src_free, bin_free);
         if (compile_cache != NULL) {
           ak = malloc(sizeof(*ak));
           av = malloc(sizeof(*av));

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -373,3 +373,27 @@ GpuElemwise *GpuElemwise_new(const gpuarray_buffer_ops *ops, void * ctx,
   free(res);
   return NULL;
 }
+
+void GpuElemwise_free(GpuElemwise *ge) {
+  GpuKernel_clear(&ge->k_contig);
+  free_args(ge->n, ge->args);
+  free(ge->preamble);
+  free(ge->expr);
+  free(ge);
+}
+
+int GpuElemwise_call(GpuElemwise *ge, void **args, int flags) {
+  size_t n;
+  int contig;
+  it err;
+  err = check_contig(ge->args, args, &n, &contig);
+  if (err == GA_NO_ERROR && contig) {
+    return call_contig(ge, args, n);
+  }
+  return GA_UNSUPPORTED_ERROR;
+  /* WIP
+  err = check_basic(ge->args, args, &n, ...);
+  if (err == GA_NO_ERROR)
+    return call_basic(ge, args, ...);
+  */
+}

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -12,7 +12,7 @@ struct _GpuElemwise {
 };
 
 static inline const char *ctype(int typecode) {
-  return gpuarray_get_type(typecode).cluda_name;
+  return gpuarray_get_type(typecode)->cluda_name;
 }
 
 /* dst has to be zero-initialized on entry */
@@ -197,7 +197,7 @@ static int gen_elemwise_contig_kernel(GpuKernel *k,
                                       const char *preamble,
                                       const char *expr,
                                       unsigned int n,
-                                      gpuelemwise_args *args) {
+                                      gpuelemwise_arg *args) {
   strb sb = STRB_STATIC_INIT;
   int *ktypes = NULL;
   unsigned int p;

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -9,6 +9,20 @@ static void decl(strb *sb, int typecode, int isarray) {
     strb_appends(sb, ctype);
 }
 
+static void decl2(strb *sb, int typecode, void *arg) {
+  int isarray = 0;
+  if (typecode == GA_BUFFER) {
+    typecode = ((GpuArray *)arg)->typecode;
+    isarray = 1;
+  }
+  const char *ctype = gpuarray_get_type(typecode).cluda_name;
+  if (ctype == NULL) strb_seterror(sb);
+  if (isarray)
+    strb_appendf(sb, "GLOBAL_MEM %s*", ctype);
+  else
+    strb_appends(sb, ctype);
+}
+
 static int gen_elemwise_basic_kernel(GpuKernel *k,
                                      const gpuarray_buffer_ops *ops,
                                      void *ctx, char **err_str,
@@ -35,8 +49,9 @@ static int gen_elemwise_basic_kernel(GpuKernel *k,
 
   apos = 0;
 
-  strb_appends(&sb, preamble);
-  strb_appends(&sb, "KERNEL void elem(const unsigned int n, ");
+  if (preamble)
+    strb_appends(&sb, preamble);
+  strb_appends(&sb, "\nKERNEL void elem(const unsigned int n, ");
   atypes[apos++] = GA_INT;
   for (i = 0; i < nd; i++) {
     strb_appendf(&sb "const ga_size dim%u", i);
@@ -102,7 +117,7 @@ static int gen_elemwise_basic_kernel(GpuKernel *k,
     }
   }
   strb_appends(&sb, expr);
-  strb_appends(&sb, "\n}\n}\n");
+  strb_appends(&sb, ";\n}\n}\n");
   if (strb_error(&sb)) {
     res = GA_MEMORY_ERROR;
     goto bail;
@@ -114,4 +129,77 @@ static int gen_elemwise_basic_kernel(GpuKernel *k,
   free(atypes);
   strb_clear(&sb);
   return res;
+}
+
+static int gen_elemwise_contig_kernel(GpuKernel *k,
+                                      const gpuarray_buffer_ops *ops,
+                                      void *ctx, char **err_str,
+                                      const char *preamble,
+                                      const char *expr,
+                                      gpuarray_args *args) {
+  strb sb = STRB_STATIC_INIT;
+  unsigned int j;
+  int flags = GA_USE_CLUDA;
+  int res;
+
+  for (j = 0; j < n; j++) {
+    flags |= gpuarray_type_flags(types[j], -1);
+  }
+
+  if (preamble)
+    strb_appends(&sb, preamble);
+  strb_appends(&sb, "\nKERNEL void elem(const ga_size n, ");
+  for (j = 0; j < args->n; j++) {
+    decl2(sb, args->types[j], args->args[j]);
+    if (args->types[j] == GA_BUFFER) {
+      strb_appendf(&sb, " %s_p,  const ga_size %s_offset",
+                   args->names[j], args->names[j]);
+    } else {
+      strb_appendf(&sb, " %s", args->names[j]);
+    }
+    if (j != (args->n - 1))
+      strb_appends(&sb, ", ");
+  }
+  strb_appends(&sb, ") {\n"
+               "const ga_size idx = LDIM_0 * GID_0 + LID_0;\n"
+               "const ga_size numThreads = LDIM_0 * GDIM_0;\n"
+               "ga_size i;\n"
+               "GLOBAL_MEM char *tmp;\n\n");
+  for (j = 0; j < args->n; j++) {
+    if (args->types[j] == GA_BUFFER) {
+      strb_appendf(&sb, "tmp = (GLOBAL_MEM char *)%s;"
+                   "tmp += %s_offset; %s = (",
+                   args->names[j], args->names[j], args->names[j]);
+      decl2(sb, args->types[j], args->args[j]);
+      strb_appends(&sb, ")tmp;\n");
+    }
+  }
+
+  strb_appends(&sb, "for (i = idx; i < n; i += numThreads) {\n");
+  for (j = 0; j < args->n; j++) {
+    if (args->types[j] == GA_BUFFER) {
+      decl2(sb, args->types[j], args->args[j]);
+      strb_appendf(&sb, " %s = &%s_p[i];", args->names[j], args->names[j]);
+    }
+  }
+  strb_appends(&sb, expr);
+  strb_appends(&sb, ";\n}\n}\n");
+
+  if (strb_error(&sb)) {
+    res = GA_MEMORY_ERROR;
+    goto bail;
+  }
+
+  res = GpuKernel_init(k, ops, ctx, 1, (const char **)&sb.s, &sb.l, "elem",
+                       args->n, args->types, flags, err_str);
+ bail:
+  strb_clear(&sb);
+  return res;
+}
+
+int gpuarray_elemwise_op(const gpuarray_buffer_ops *ops, void * ctx,
+                         const char *preamble, const char *expr,
+                         unsigned int n, const in *types, void **args,
+                         int flags, char **err_str) {
+  // TODO
 }

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -298,15 +298,18 @@ static int check_basic(GpuElemwise *ge, void **args, int flags,
           if (dims[j] == 1) {
             dims[j] = v->dimensions[j];
           } else {
-            if (v->dimensions[j] == 1) {
-              strs[p][j] = 0;
-            } else {
+            if (v->dimensions[j] != 1) {
               err = GA_VALUE_ERROR;
               goto error;
             }
           }
         }
-      p++;
+        /* If the dimension is 1 set the strides to 0 regardless since
+           it won't change anything in the non-broadcast case. */
+        if (v->dimensions[j] == 1) {
+          strs[p][j] = 0;
+        }
+        p++;
       } /* is_array() */
     } /* for each arg */
     /* We have the final value in dims[j] */

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -1,0 +1,117 @@
+#include "util/strb.h"
+
+static void decl(strb *sb, int typecode, int isarray) {
+  const char *ctype = gpuarray_get_type(typecode).cluda_name;
+  if (ctype == NULL) strb_seterror(sb);
+  if (isarray)
+    strb_appendf(sb, "GLOBAL_MEM %s*", ctype);
+  else
+    strb_appends(sb, ctype);
+}
+
+static int gen_elemwise_basic_kernel(GpuKernel *k,
+                                     const gpuarray_buffer_ops *ops,
+                                     void *ctx, char **err_str,
+                                     const char *preamble,
+                                     unsigned int nd, const char *expr,
+                                     unsigned int n, const char **name
+                                     const int *types, const int *isarray) {
+  strb sb = STRB_STATIC_INIT;
+  unsigned int i, _i, j;
+  int *atypes;
+  size_t nargs, apos;
+  int flags = GA_USE_CLUDA;
+  int res;
+
+  nargs = 1 + nd;
+  for (j = 0; j < n; j++) {
+    nargs += isarray[j] ? (2 + nd) : 1;
+    flags |= gpuarray_type_flags(types[j], -1);
+  }
+
+  atypes = calloc(nargs, sizeof(int));
+  if (atypes == NULL)
+    return GA_MEMORY_ERROR;
+
+  apos = 0;
+
+  strb_appends(&sb, preamble);
+  strb_appends(&sb, "KERNEL void elem(const unsigned int n, ");
+  atypes[apos++] = GA_INT;
+  for (i = 0; i < nd; i++) {
+    strb_appendf(&sb "const ga_size dim%u", i);
+    atypes[apos++] = GA_SIZE;
+  }
+  for (j = 0; j < n; j++) {
+    decl(&sb, types[j], isarray[j]);
+    if (isarray[i]) {
+      strb_appendf(&sb " %s_data, const ga_size %s_offset, ", name[j], name[j]);
+      atypes[apos++] = GA_BUFFER;
+      atypes[apos++] = GA_SIZE;
+
+      for (i = 0; i < nd; i++) {
+        strb_appendf(&sb, "const ga_ssize %s_str_%u%s", name[j], i,
+                     (i == (nd - 1)) ? "", ", ");
+        atypes[apos++] = GA_SSIZE;
+      }
+    } else {
+      strb_appendsf(&sb " %s", name[j]);
+      atypes[apos++] = types[j];
+    }
+    if (j != (n - 1)) strb_appends(&sb, ", ");
+  }
+  strb_appends(&sb, ") {\n"
+               "const unsigned int idx = LDIM_0 * GID_0 + LID_0;\n"
+               "const unsigned int numThreads = LDIM_0 * GDIM_0;\n"
+               "unsigned int i;\n"
+               "GLOBAL_MEM char *tmp;\n\n");
+  for (j = 0; j < n; j++) {
+    if (isarray[j]) {
+      strb_appendf(&sb, "tmp = (GLOBAL_MEM char *)%s_data; tmp += %s_offset; "
+                   "%s_data = (", name[j], name[j], name[j]);
+      decl(sb, types[j], isarray[j]);
+      strb_appends(&sb, ")tmp;\n");
+    }
+  }
+
+  strb_appends(&sb, "for i = idx; i < n; i += numThreads) {\n");
+  if (nd > 0)
+    strb_appends(&sb, "int ii = i;\nint pos;\n");
+  for (j = 0; j < n; j++) {
+    if (isarray[j])
+      strb_appendf(&sb, "GLOBAL_MEM char *%s_p = (GLOBAL_MEM char *)%s_data;\n",
+                   name[j], name[j]);
+  }
+  for (_i = nd; _i > 0; _i--) {
+    i = _i - 1;
+    if (i > 0)
+      strb_appendf(&sb, "pos = ii % dim%u;\nii = ii / dim%u;\n", i, i);
+    else
+      strb_appends(&sb, "pos = ii;\n");
+    for (j = 0; j < n; j++) {
+      if (isarray[j])
+        strb_appendf(&sb, "%s_p += pos * %s_str_%u;\n", name[j], name[j], i);
+    }
+  }
+  for (j = 0; j < n; j++) {
+    if (isarray[j]) {
+      decl(sb, types[j], isarray[j]);
+      strb_appendf(&sb, " %s = (", name[j]);
+      decl(sb, types[j], isarray[j]);
+      strb_appendf(&sb, ")%s_p;\n", name[j]);
+    }
+  }
+  strb_appends(&sb, expr);
+  strb_appends(&sb, "\n}\n}\n");
+  if (strb_error(&sb)) {
+    res = GA_MEMORY_ERROR;
+    goto bail;
+  }
+
+  res = GpuKernel_init(k, ops, ctx, 1, (const char **)&sb.s, &sb.l, "elem",
+                       nargs, atypes, flags, err_str);
+ bail:
+  free(atypes);
+  strb_clear(&sb);
+  return res;
+}

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -234,7 +234,7 @@ static int check_basic(GpuElemwise *ge, void **args, int flags,
   size_t *dims;
   size_t n;
   GpuArray *a = NULL, *v;
-  unsigned int i, j, p, num_arrays = 0, nd;
+  unsigned int i, j, p, num_arrays = 0, nd = 0;
   int err;
 
   /* Go through the list and grab some info */

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -627,6 +627,9 @@ fail_basic_gen:
 void GpuElemwise_free(GpuElemwise *ge) {
   unsigned int i;
   for (i = 0; i < ge->nd; i++) {
+    GpuKernel_clear(&ge->k_basic_32[i]);
+  }
+  for (i = 0; i < ge->nd; i++) {
     GpuKernel_clear(&ge->k_basic[i]);
   }
   GpuKernel_clear(&ge->k_contig);

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -136,7 +136,7 @@ static int gen_elemwise_basic_kernel(GpuKernel *k,
 
   strb_appends(&sb, "for(i = idx; i < n; i += numThreads) {\n");
   if (nd > 0)
-    strb_appends(&sb, "int ii = i;\nint pos;\n");
+    strb_appends(&sb, "ga_size ii = i;\nga_size pos;\n");
   for (j = 0; j < n; j++) {
     if (is_array(args[j]))
       strb_appendf(&sb, "GLOBAL_MEM char *%s_p = (GLOBAL_MEM char *)%s_data;\n",

--- a/src/gpuarray_kernel.c
+++ b/src/gpuarray_kernel.c
@@ -70,6 +70,10 @@ int GpuKernel_sched(GpuKernel *k, size_t n, size_t *ls, size_t *gs) {
   return GA_NO_ERROR;
 }
 
+int GpuKernel_setarg(GpuKernel *k, unsigned int i, void *a) {
+  return k->ops->kernel_setarg(k->k, i, a);
+}
+
 int GpuKernel_call(GpuKernel *k, unsigned int n,
                    const size_t *bs, const size_t *gs,
                    size_t shared, void **args) {

--- a/src/gpuarray_kernel.c
+++ b/src/gpuarray_kernel.c
@@ -39,8 +39,12 @@ void *GpuKernel_context(GpuKernel *k) {
 int GpuKernel_sched(GpuKernel *k, size_t n, size_t *ls, size_t *gs) {
   size_t min_l;
   size_t max_l;
+  size_t target_l;
   size_t max_g;
+  size_t target_g;
+  unsigned int numprocs;
   int err;
+  int want_ls = 0;
 
   err = k->ops->property(NULL, NULL, k->k, GA_KERNEL_PROP_MAXLSIZE, &max_l);
   if (err != GA_NO_ERROR)
@@ -48,25 +52,38 @@ int GpuKernel_sched(GpuKernel *k, size_t n, size_t *ls, size_t *gs) {
   err = k->ops->property(NULL, NULL, k->k, GA_KERNEL_PROP_PREFLSIZE, &min_l);
   if (err != GA_NO_ERROR)
     return err;
-  err = k->ops->property(GpuKernel_context(k), NULL, NULL,
-                         GA_CTX_PROP_MAXGSIZE, &max_g);
+  err = k->ops->property(NULL, NULL, k->k, GA_CTX_PROP_NUMPROCS, &numprocs);
   if (err != GA_NO_ERROR)
     return err;
-  if (*gs == 0) {
-    if (*ls == 0) {
-      if (n < max_l)
-        *ls = min_l;
-      else
-        *ls = max_l;
-    }
-    *gs = ((n-1) / (*ls)) + 1;
-    if (*gs > max_g)
-      *gs = max_g;
-  } else if (*ls == 0) {
-    *ls = (n-1) / ((*gs)-1);
-    if (*ls > max_l)
-      *ls = max_l;
+  err = k->ops->property(NULL, NULL, k->k, GA_CTX_PROP_MAXGSIZE, &max_g);
+  if (err != GA_NO_ERROR)
+    return err;
+
+  /* Do something about these hardcoded values */
+  target_g = numprocs * 32;
+  if (target_g > max_g)
+    target_g = max_g;
+  target_l = 512;
+  if (target_l > max_l)
+    target_l = max_l;
+
+  if (*ls == 0) {
+    want_ls = 1;
+    *ls = min_l;
   }
+
+  if (*gs == 0) {
+    *gs = ((n-1) / *ls) + 1;
+    if (*gs > target_g)
+      *gs = target_g;
+  }
+
+  if (want_ls) {
+    *ls = (n-1) / ((*gs)-1);
+    if (*ls > target_l)
+      *ls = target_l;
+  }
+
   return GA_NO_ERROR;
 }
 

--- a/src/gpuarray_kernel.c
+++ b/src/gpuarray_kernel.c
@@ -73,15 +73,15 @@ int GpuKernel_sched(GpuKernel *k, size_t n, size_t *ls, size_t *gs) {
   }
 
   if (*gs == 0) {
-    *gs = ((n-1) / *ls);
+    *gs = ((n-1) / *ls) + 1;
     if (*gs > target_g)
       *gs = target_g;
   }
 
-  if (want_ls) {
+  if (want_ls && n > (*ls * *gs)) {
     /* The division and multiplication by min_l is to ensure we end up
      * with a multiple of min_l */
-    *ls = (((n-1) / min_l) / *gs) * min_l;
+    *ls = ((n / min_l) / *gs) * min_l;
     if (*ls > target_l)
       *ls = target_l;
   }

--- a/src/gpuarray_kernel.c
+++ b/src/gpuarray_kernel.c
@@ -73,13 +73,15 @@ int GpuKernel_sched(GpuKernel *k, size_t n, size_t *ls, size_t *gs) {
   }
 
   if (*gs == 0) {
-    *gs = ((n-1) / *ls) + 1;
+    *gs = ((n-1) / *ls);
     if (*gs > target_g)
       *gs = target_g;
   }
 
   if (want_ls) {
-    *ls = (n-1) / ((*gs)-1);
+    /* The division and multiplication by min_l is to ensure we end up
+     * with a multiple of min_l */
+    *ls = (((n-1) / min_l) / *gs) * min_l;
     if (*ls > target_l)
       *ls = target_l;
   }

--- a/src/gpuarray_util.c
+++ b/src/gpuarray_util.c
@@ -1,10 +1,12 @@
 #include <assert.h>
 
 #include "private.h"
+#include "util/strb.h"
+
 #include "gpuarray/util.h"
 #include "gpuarray/error.h"
 #include "gpuarray/kernel.h"
-#include "util/strb.h"
+#include "gpuarray/elemwise.h"
 
 /*
  * API version is negative since we are still in the development

--- a/src/gpuarray_util.c
+++ b/src/gpuarray_util.c
@@ -109,6 +109,19 @@ void gpukernel_source_with_line_numbers(unsigned int count,
   }
 }
 
+static int get_flags(int typecode) {
+  int flags = 0;
+  if (typecode == GA_DOUBLE || typecode == GA_CDOUBLE)
+    flags |= GA_USE_DOUBLE;
+  if (typecode == GA_HALF)
+    flags |= GA_USE_HALF;
+  if (typecode == GA_CFLOAT || typecode == GA_CDOUBLE)
+    flags |= GA_USE_COMPLEX;
+  if (gpuarray_get_elsize(typecode) < 4)
+    flags |= GA_USE_SMALL;
+  return flags;
+}
+
 /* List of typecodes terminated by -1 */
 int gpuarray_type_flags(int init, ...) {
   va_list ap;
@@ -117,17 +130,19 @@ int gpuarray_type_flags(int init, ...) {
 
   va_start(ap, init);
   while (typecode != -1) {
-    if (typecode == GA_DOUBLE || typecode == GA_CDOUBLE)
-      flags |= GA_USE_DOUBLE;
-    if (typecode == GA_HALF)
-      flags |= GA_USE_HALF;
-    if (typecode == GA_CFLOAT || typecode == GA_CDOUBLE)
-      flags |= GA_USE_COMPLEX;
-    if (gpuarray_get_elsize(typecode) < 4)
-      flags |= GA_USE_SMALL;
+    flags |= get_flags(typecode);
     typecode = va_arg(ap, int);
   }
   va_end(ap);
+  return flags;
+}
+
+int gpuarray_type_flagsa(unsigned int n, gpuelemwise_arg *args) {
+  unsigned int i;
+  int flags = 0;
+  for (i = 0; i < n; i++) {
+    flags |= get_flags(args[i].typecode);
+  }
   return flags;
 }
 

--- a/src/gpuarray_util.c
+++ b/src/gpuarray_util.c
@@ -111,7 +111,7 @@ void gpukernel_source_with_line_numbers(unsigned int count,
   }
 }
 
-static int get_flags(int typecode) {
+static int get_type_flags(int typecode) {
   int flags = 0;
   if (typecode == GA_DOUBLE || typecode == GA_CDOUBLE)
     flags |= GA_USE_DOUBLE;
@@ -132,7 +132,7 @@ int gpuarray_type_flags(int init, ...) {
 
   va_start(ap, init);
   while (typecode != -1) {
-    flags |= get_flags(typecode);
+    flags |= get_type_flags(typecode);
     typecode = va_arg(ap, int);
   }
   va_end(ap);
@@ -143,7 +143,7 @@ int gpuarray_type_flagsa(unsigned int n, gpuelemwise_arg *args) {
   unsigned int i;
   int flags = 0;
   for (i = 0; i < n; i++) {
-    flags |= get_flags(args[i].typecode);
+    flags |= get_type_flags(args[i].typecode);
   }
   return flags;
 }

--- a/src/gpuarray_util.c
+++ b/src/gpuarray_util.c
@@ -13,8 +13,8 @@
  * phase. Once we go stable, this will move to 0 and go up from
  * there.
  */
-const int gpuarray_api_major = -10000;
-const int gpuarray_api_minor = 2;
+const int gpuarray_api_major = -9999;
+const int gpuarray_api_minor = 0;
 
 static gpuarray_type **custom_types = NULL;
 static int n_types = 0;

--- a/src/private.h
+++ b/src/private.h
@@ -49,6 +49,12 @@ GPUARRAY_LOCAL void gpukernel_source_with_line_numbers(unsigned int count,
                                                        size_t *newl,
                                                        strb *src);
 
+#define ISSET(v, fl) ((v) & (fl))
+#define ISCLR(v, fl) (!((v) & (fl)))
+
+#define FLSET(v, fl) (v |= (fl))
+#define FLCLR(v, fl) (v &= ~(fl))
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/private_opencl.h
+++ b/src/private_opencl.h
@@ -64,10 +64,12 @@ struct _gpukernel {
 #endif
   cl_kernel k;
   cl_event ev;
-  unsigned int argcount;
-  int *types;
+  cl_event **evr;
   cl_ctx *ctx;
+  int *types;
+  unsigned int argcount;
   unsigned int refcnt;
+  cl_uint num_ev;
 };
 
 GPUARRAY_LOCAL cl_ctx *cl_make_ctx(cl_context ctx);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(check_util main.c check_util.c)
 target_link_libraries(check_util ${LIBS} gpuarray)
 add_test(test_util ${CMAKE_CURRENT_BINARY_DIR}/check_util)
 
-add_executable(check_array main.c check_array.c)
+add_executable(check_array main.c device.c check_array.c)
 target_link_libraries(check_array ${LIBS} gpuarray)
 add_test(test_array ${CMAKE_CURRENT_BINARY_DIR}/check_array)
 
@@ -32,7 +32,7 @@ add_executable(check_error main.c check_error.c)
 target_link_libraries(check_error ${LIBS} gpuarray)
 add_test(test_error ${CMAKE_CURRENT_BINARY_DIR}/check_error)
 
-add_executable(check_buffer main.c check_buffer.c)
+add_executable(check_buffer main.c device.c check_buffer.c)
 target_link_libraries(check_buffer ${LIBS} gpuarray)
 add_test(test_buffer ${CMAKE_CURRENT_BINARY_DIR}/check_buffer)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,10 @@ add_executable(check_array main.c device.c check_array.c)
 target_link_libraries(check_array ${LIBS} gpuarray)
 add_test(test_array ${CMAKE_CURRENT_BINARY_DIR}/check_array)
 
+add_executable(check_elemwise main.c device.c check_elemwise.c)
+target_link_libraries(check_elemwise ${LIBS} gpuarray)
+add_test(test_elemwise ${CMAKE_CURRENT_BINARY_DIR}/check_elemwise)
+
 add_executable(check_error main.c check_error.c)
 target_link_libraries(check_error ${LIBS} gpuarray)
 add_test(test_error ${CMAKE_CURRENT_BINARY_DIR}/check_error)

--- a/tests/check_array.c
+++ b/tests/check_array.c
@@ -6,65 +6,14 @@
 #include <limits.h>
 #include <stdlib.h>
 
-void *ctx;
-const gpuarray_buffer_ops *ops;
+extern void *ctx;
+extern const gpuarray_buffer_ops *ops;
+
+void setup(void);
+void teardown(void);
 
 #define ga_assert_ok(e) ck_assert_int_eq(e, GA_NO_ERROR)
 
-int get_env_dev(const gpuarray_buffer_ops **o) {
-  char *dev;
-  char *end;
-  long no;
-  int d;
-  if ((dev = getenv("GPUARRAY_TEST_DEVICE")) == NULL) {
-    if ((dev = getenv("DEVICE")) == NULL) {
-      *o = gpuarray_get_ops("opencl");
-      return 0; /* opencl0:0 */
-    }
-  }
-  if (strncmp(dev, "cuda", 4) == 0) {
-    *o = gpuarray_get_ops("cuda");
-    no = strtol(dev + 4, &end, 10);
-    if (end == dev || *end != '\0')
-      return -1;
-    if (no < 0 || no > INT_MAX)
-      return -1; 
-    return (int)no;
-  }
-  if (strncmp(dev, "opencl", 6) == 0) {
-    *o = gpuarray_get_ops("opencl");
-    no = strtol(dev + 6, &end, 10);
-    if (end == dev || *end != ':')
-      return -1;
-    if (no < 0 || no > 32768)
-      return -1;
-    d = (int)no;
-    dev = end;
-    no = strtol(dev + 1, &end, 10);
-    if (end == dev || *end != '\0')
-      return -1;
-    if (no < 0 || no > 32768)
-      return -1;
-    d <<= 16;
-    d |= (int)no;
-    return d;
-  }
-  return -1;
-}
-
-void setup(void) {
-  int dev = get_env_dev(&ops);
-  if (dev == -1)
-    ck_abort_msg("Bad test device");
-  ctx = ops->buffer_init(dev, 0, NULL);
-  ck_assert_ptr_ne(ctx, NULL);
-}
-
-void teardown(void) {
-  ops->buffer_deinit(ctx);
-  ctx = NULL;
-  ops = NULL;
-}
 
 START_TEST(test_take1_ok)
 {

--- a/tests/check_buffer.c
+++ b/tests/check_buffer.c
@@ -4,58 +4,28 @@
 #include "gpuarray/error.h"
 #include "private.h"
 
+extern void *ctx;
+extern const gpuarray_buffer_ops *ops;
+
+void setup(void);
+void teardown(void);
+
 START_TEST(test_get_ops)
 {
-  const gpuarray_buffer_ops *ops;
-  int valid_ops = 0;
-  ops = gpuarray_get_ops("cuda");
-  if (ops != NULL) valid_ops++;
-  ops = gpuarray_get_ops("opencl");
-  if (ops != NULL) valid_ops++;
-  ck_assert_msg(valid_ops > 0, "No backends are available");
-
   ops = gpuarray_get_ops("potato");
   ck_assert(ops == NULL);
 }
 END_TEST
 
-static char *BACKENDS[] = {"opencl", "cuda"};
-
 START_TEST(test_gpu_error)
 {
-  const gpuarray_buffer_ops *ops;
   const char *msg;
-  ops = gpuarray_get_ops(BACKENDS[_i]);
-  if (ops == NULL) return;
   msg = Gpu_error(ops, NULL, -1);
   msg = Gpu_error(ops, NULL, 99);
   msg = Gpu_error(ops, NULL, GA_NO_ERROR);
   ck_assert_str_eq(msg, "No error");
 }
 END_TEST
-
-static const gpuarray_buffer_ops *ops;
-static void *ctx;
-
-static int setup(int i) {
-  int j;
-  ops = gpuarray_get_ops(BACKENDS[i]);
-  if (ops == NULL)
-    return 0;
-  for (j = 0; j < 5; j++) {
-    ctx = ops->buffer_init(j, 0, NULL);
-    if (ctx != NULL)
-      return 1;
-  }
-  return 0;
-}
-
-static void teardown(void) {
-  if (ctx != NULL) {
-    ops->buffer_deinit(ctx);
-    ctx = NULL;
-  }
-}
 
 static unsigned int refcnt(gpudata *b) {
   unsigned int res;
@@ -65,37 +35,24 @@ static unsigned int refcnt(gpudata *b) {
   return res;
 }
 
-START_TEST(test_buffer_init)
-{
-  if (setup(_i)) {
-    ops->buffer_deinit(ctx);
-    ctx = NULL;
-  }
-  teardown();
-}
-END_TEST
-
 START_TEST(test_buffer_alloc)
 {
   gpudata *d;
 
-  if (setup(_i)) {
-    d = ops->buffer_alloc(ctx, 0, NULL, 0, NULL);
-    ck_assert(d != NULL);
-    ck_assert_int_eq(refcnt(d), 1);
-    ops->buffer_release(d);
+  d = ops->buffer_alloc(ctx, 0, NULL, 0, NULL);
+  ck_assert(d != NULL);
+  ck_assert_int_eq(refcnt(d), 1);
+  ops->buffer_release(d);
 
-    d = ops->buffer_alloc(ctx, 1, NULL, 0, NULL);
-    ck_assert(d != NULL);
-    ck_assert_int_eq(refcnt(d), 1);
-    ops->buffer_release(d);
+  d = ops->buffer_alloc(ctx, 1, NULL, 0, NULL);
+  ck_assert(d != NULL);
+  ck_assert_int_eq(refcnt(d), 1);
+  ops->buffer_release(d);
 
-    d = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
-    ck_assert(d != NULL);
-    ck_assert_int_eq(refcnt(d), 1);
-    ops->buffer_release(d);
-  }
-  teardown();
+  d = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
+  ck_assert(d != NULL);
+  ck_assert_int_eq(refcnt(d), 1);
+  ops->buffer_release(d);
 }
 END_TEST
 
@@ -104,42 +61,39 @@ START_TEST(test_buffer_retain_release)
   gpudata *d;
   gpudata *d2;
 
-  if (setup(_i)) {
-    d = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
-    ck_assert(d != NULL);
-    ck_assert_int_eq(refcnt(d), 1);
+  d = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
+  ck_assert(d != NULL);
+  ck_assert_int_eq(refcnt(d), 1);
 
-    d2 = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
-    ck_assert(d2 != NULL);
-    ck_assert_int_eq(refcnt(d2), 1);
+  d2 = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
+  ck_assert(d2 != NULL);
+  ck_assert_int_eq(refcnt(d2), 1);
 
-    ops->buffer_retain(d);
-    ck_assert_int_eq(refcnt(d), 2);
+  ops->buffer_retain(d);
+  ck_assert_int_eq(refcnt(d), 2);
 
-    ops->buffer_release(d);
-    ck_assert_int_eq(refcnt(d), 1);
+  ops->buffer_release(d);
+  ck_assert_int_eq(refcnt(d), 1);
 
-    ops->buffer_retain(d);
-    ops->buffer_retain(d2);
-    ops->buffer_retain(d);
-    ck_assert_int_eq(refcnt(d), 3);
-    ck_assert_int_eq(refcnt(d2), 2);
+  ops->buffer_retain(d);
+  ops->buffer_retain(d2);
+  ops->buffer_retain(d);
+  ck_assert_int_eq(refcnt(d), 3);
+  ck_assert_int_eq(refcnt(d2), 2);
 
-    ops->buffer_release(d);
-    ck_assert_int_eq(refcnt(d), 2);
-    ck_assert_int_eq(refcnt(d2), 2);
+  ops->buffer_release(d);
+  ck_assert_int_eq(refcnt(d), 2);
+  ck_assert_int_eq(refcnt(d2), 2);
 
-    ops->buffer_release(d);
-    ops->buffer_release(d2);
-    ck_assert_int_eq(refcnt(d), 1);
-    ck_assert_int_eq(refcnt(d2), 1);
+  ops->buffer_release(d);
+  ops->buffer_release(d2);
+  ck_assert_int_eq(refcnt(d), 1);
+  ck_assert_int_eq(refcnt(d2), 1);
 
-    ops->buffer_release(d);
-    ck_assert_int_eq(refcnt(d2), 1);
+  ops->buffer_release(d);
+  ck_assert_int_eq(refcnt(d2), 1);
 
-    ops->buffer_release(d2);
-  }
-  teardown();
+  ops->buffer_release(d2);
 }
 END_TEST
 
@@ -148,18 +102,13 @@ START_TEST(test_buffer_share)
   gpudata *d;
   gpudata *d2;
 
-  if (setup(_i)) {
-    d = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
-    ck_assert(d != NULL);
-    d2 = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
-    ck_assert(d2 != NULL);
+  d = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
+  ck_assert(d != NULL);
+  d2 = ops->buffer_alloc(ctx, 1024, NULL, 0, NULL);
+  ck_assert(d2 != NULL);
 
-    ck_assert_int_eq(ops->buffer_share(d, d2, NULL), 0);
-    ck_assert_int_eq(ops->buffer_share(d, d, NULL), 1);
-
-    /* TODO: test for OpenCL subbuffers and Cuda overlapping allocations */
-  }
-  teardown();
+  ck_assert_int_eq(ops->buffer_share(d, d2, NULL), 0);
+  ck_assert_int_eq(ops->buffer_share(d, d, NULL), 1);
 }
 END_TEST
 
@@ -171,43 +120,39 @@ START_TEST(test_buffer_read_write)
   int err;
   unsigned int i;
 
-  if (setup(_i)) {
-    d = ops->buffer_alloc(ctx, sizeof(data), NULL, 0, NULL);
-    ck_assert(d != NULL);
+  d = ops->buffer_alloc(ctx, sizeof(data), NULL, 0, NULL);
+  ck_assert(d != NULL);
 
-    err = ops->buffer_write(d, 0, data, sizeof(data));
-    ck_assert_int_eq(err, GA_NO_ERROR);
+  err = ops->buffer_write(d, 0, data, sizeof(data));
+  ck_assert_int_eq(err, GA_NO_ERROR);
 
-    memset(buf, 0, sizeof(data));
-    err = ops->buffer_read(buf, d, 0, sizeof(data));
-    ck_assert_int_eq(err, GA_NO_ERROR);
-    for (i = 0; i < nelems(data); i++) {
-      ck_assert_int_eq(data[i], buf[i]);
-    }
-
-    memset(buf, 0, sizeof(data));
-    err = ops->buffer_read(buf, d, sizeof(int32_t), sizeof(data)-sizeof(int32_t));
-    ck_assert_int_eq(err, GA_NO_ERROR);
-    for (i = 0; i < nelems(data)-1; i++) {
-      ck_assert_int_eq(data[i+1], buf[i]);
-
-    }
-
-    err = ops->buffer_write(d, sizeof(int32_t)*2, data, sizeof(data)-(sizeof(int32_t)*2));
-    ck_assert_int_eq(err, GA_NO_ERROR);
-
-    memset(buf, 0, sizeof(data));
-    err = ops->buffer_read(buf, d, 0, sizeof(data));
-    ck_assert_int_eq(err, GA_NO_ERROR);
-    for (i = 0; i < nelems(data)-2; i++) {
-      ck_assert_int_eq(data[i], buf[i+2]);
-    }
-    for (i = 0; i < 2; i++) {
-      ck_assert_int_eq(data[i], buf[i]);
-    }
-    ops->buffer_release(d);
+  memset(buf, 0, sizeof(data));
+  err = ops->buffer_read(buf, d, 0, sizeof(data));
+  ck_assert_int_eq(err, GA_NO_ERROR);
+  for (i = 0; i < nelems(data); i++) {
+    ck_assert_int_eq(data[i], buf[i]);
   }
-  teardown();
+
+  memset(buf, 0, sizeof(data));
+  err = ops->buffer_read(buf, d, sizeof(int32_t), sizeof(data)-sizeof(int32_t));
+  ck_assert_int_eq(err, GA_NO_ERROR);
+  for (i = 0; i < nelems(data)-1; i++) {
+    ck_assert_int_eq(data[i+1], buf[i]);
+  }
+
+  err = ops->buffer_write(d, sizeof(int32_t)*2, data, sizeof(data)-(sizeof(int32_t)*2));
+  ck_assert_int_eq(err, GA_NO_ERROR);
+
+  memset(buf, 0, sizeof(data));
+  err = ops->buffer_read(buf, d, 0, sizeof(data));
+  ck_assert_int_eq(err, GA_NO_ERROR);
+  for (i = 0; i < nelems(data)-2; i++) {
+    ck_assert_int_eq(data[i], buf[i+2]);
+  }
+  for (i = 0; i < 2; i++) {
+    ck_assert_int_eq(data[i], buf[i]);
+  }
+  ops->buffer_release(d);
 }
 END_TEST
 
@@ -220,53 +165,50 @@ START_TEST(test_buffer_move)
   int err;
   unsigned int i;
 
-  if (setup(_i)) {
-    d = ops->buffer_alloc(ctx, sizeof(data), NULL, 0, NULL);
-    ck_assert(d != NULL);
-    d2 = ops->buffer_alloc(ctx, sizeof(data)*2, NULL, 0, NULL);
-    ck_assert(d != NULL);
+  d = ops->buffer_alloc(ctx, sizeof(data), NULL, 0, NULL);
+  ck_assert(d != NULL);
+  d2 = ops->buffer_alloc(ctx, sizeof(data)*2, NULL, 0, NULL);
+  ck_assert(d != NULL);
 
-    err = ops->buffer_write(d, 0, data, sizeof(data));
-    ck_assert(err == GA_NO_ERROR);
+  err = ops->buffer_write(d, 0, data, sizeof(data));
+  ck_assert(err == GA_NO_ERROR);
 
-    err = ops->buffer_move(d2, sizeof(data), d, 0, sizeof(data));
-    ck_assert(err == GA_NO_ERROR);
+  err = ops->buffer_move(d2, sizeof(data), d, 0, sizeof(data));
+  ck_assert(err == GA_NO_ERROR);
 
-    err = ops->buffer_read(buf, d2, sizeof(data), sizeof(data));
-    ck_assert(err == GA_NO_ERROR);
-    for (i = 0; i < nelems(data); i++) {
-      ck_assert_int_eq(buf[i], data[i]);
-    }
-
-    err = ops->buffer_move(d2, 0, d, sizeof(uint32_t), sizeof(data)-sizeof(uint32_t));
-    ck_assert(err == GA_NO_ERROR);
-
-    err = ops->buffer_read(buf, d2, 0, sizeof(data));
-    ck_assert(err == GA_NO_ERROR);
-    for (i = 0; i < nelems(data)-1; i++) {
-      ck_assert_int_eq(buf[i], data[i+1]);
-    }
-
-    ops->buffer_release(d);
-    ops->buffer_release(d2);
+  err = ops->buffer_read(buf, d2, sizeof(data), sizeof(data));
+  ck_assert(err == GA_NO_ERROR);
+  for (i = 0; i < nelems(data); i++) {
+    ck_assert_int_eq(buf[i], data[i]);
   }
-  teardown();
+
+  err = ops->buffer_move(d2, 0, d, sizeof(uint32_t), sizeof(data)-sizeof(uint32_t));
+  ck_assert(err == GA_NO_ERROR);
+
+  err = ops->buffer_read(buf, d2, 0, sizeof(data));
+  ck_assert(err == GA_NO_ERROR);
+  for (i = 0; i < nelems(data)-1; i++) {
+    ck_assert_int_eq(buf[i], data[i+1]);
+  }
+
+  ops->buffer_release(d);
+  ops->buffer_release(d2);
 }
 END_TEST
 
 Suite *get_suite(void) {
   Suite *s = suite_create("buffer");
-  TCase *tc = tcase_create("All");
+  TCase *tc = tcase_create("init");
   tcase_add_test(tc, test_get_ops);
-  tcase_add_loop_test(tc, test_gpu_error, 0, nelems(BACKENDS));
   suite_add_tcase(s, tc);
   tc = tcase_create("API");
-  tcase_add_loop_test(tc, test_buffer_init, 0, nelems(BACKENDS));
-  tcase_add_loop_test(tc, test_buffer_alloc, 0, nelems(BACKENDS));
-  tcase_add_loop_test(tc, test_buffer_retain_release, 0, nelems(BACKENDS));
-  tcase_add_loop_test(tc, test_buffer_share, 0, nelems(BACKENDS));
-  tcase_add_loop_test(tc, test_buffer_read_write, 0, nelems(BACKENDS));
-  tcase_add_loop_test(tc, test_buffer_move, 0, nelems(BACKENDS));
+  tcase_add_checked_fixture(tc, setup, teardown);
+  tcase_add_test(tc, test_gpu_error);
+  tcase_add_test(tc, test_buffer_alloc);
+  tcase_add_test(tc, test_buffer_retain_release);
+  tcase_add_test(tc, test_buffer_share);
+  tcase_add_test(tc, test_buffer_read_write);
+  tcase_add_test(tc, test_buffer_move);
   suite_add_tcase(s, tc);
   return s;
 }

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -204,6 +204,79 @@ START_TEST(test_basic_remove1)
 }
 END_TEST
 
+
+START_TEST(test_basic_broadcast)
+{
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+
+  GpuElemwise *ge;
+
+  static const uint32_t data1[3] = {1, 2, 3};
+  static const uint32_t data2[2] = {4, 5};
+  uint32_t data3[6] = {0};
+
+  size_t dims[2];
+
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
+  dims[0] = 1;
+  dims[1] = 3;
+
+  ga_assert_ok(GpuArray_empty(&a, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  dims[0] = 2;
+  dims[1] = 1;
+
+  ga_assert_ok(GpuArray_empty(&b, ops, ctx, GA_UINT, 2, dims, GA_F_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  dims[0] = 2;
+  dims[1] = 3;
+
+  ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].nd = 2;
+  args[0].typecode = GA_UINT;
+  args[0].flags = GE_READ;
+
+  args[1].name = "b";
+  args[1].nd = 2;
+  args[1].typecode = GA_UINT;
+  args[1].flags = GE_READ;
+
+  args[2].name = "c";
+  args[2].nd = 2;
+  args[2].typecode = GA_UINT;
+  args[2].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &b;
+  rargs[2] = &c;
+
+  ck_assert_int_eq(GpuElemwise_call(ge, rargs, GE_NOCOLLAPSE), GA_VALUE_ERROR);
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_NOCOLLAPSE|GE_BROADCAST));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], 5);
+  ck_assert_int_eq(data3[1], 6);
+  ck_assert_int_eq(data3[2], 7);
+  ck_assert_int_eq(data3[3], 6);
+  ck_assert_int_eq(data3[4], 7);
+  ck_assert_int_eq(data3[5], 8);
+}
+END_TEST
+
 Suite *get_suite(void) {
   Suite *s = suite_create("elemwise");
   TCase *tc = tcase_create("contig");
@@ -214,6 +287,7 @@ Suite *get_suite(void) {
   tcase_add_checked_fixture(tc, setup, teardown);
   tcase_add_test(tc, test_basic_simple);
   tcase_add_test(tc, test_basic_remove1);
+  tcase_add_test(tc, test_basic_broadcast);
   suite_add_tcase(s, tc);
   return s;
 }

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -277,6 +277,71 @@ START_TEST(test_basic_broadcast)
 }
 END_TEST
 
+
+START_TEST(test_basic_collapse)
+{
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+
+  GpuElemwise *ge;
+
+  static const uint32_t data1[6] = {1, 2, 3, 4, 5, 6};
+  static const uint32_t data2[6] = {7, 8, 9, 10, 11, 12};
+  uint32_t data3[6] = {0};
+
+  size_t dims[2];
+
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
+  dims[0] = 2;
+  dims[1] = 3;
+
+  ga_assert_ok(GpuArray_empty(&a, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  ga_assert_ok(GpuArray_empty(&b, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].nd = 2;
+  args[0].typecode = GA_UINT;
+  args[0].flags = GE_READ;
+
+  args[1].name = "b";
+  args[1].nd = 2;
+  args[1].typecode = GA_UINT;
+  args[1].flags = GE_READ;
+
+  args[2].name = "c";
+  args[2].nd = 2;
+  args[2].typecode = GA_UINT;
+  args[2].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &b;
+  rargs[2] = &c;
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, 0));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], 8);
+  ck_assert_int_eq(data3[1], 10);
+  ck_assert_int_eq(data3[2], 12);
+  ck_assert_int_eq(data3[3], 14);
+  ck_assert_int_eq(data3[4], 16);
+  ck_assert_int_eq(data3[5], 18);
+}
+END_TEST
+
 Suite *get_suite(void) {
   Suite *s = suite_create("elemwise");
   TCase *tc = tcase_create("contig");
@@ -288,6 +353,7 @@ Suite *get_suite(void) {
   tcase_add_test(tc, test_basic_simple);
   tcase_add_test(tc, test_basic_remove1);
   tcase_add_test(tc, test_basic_broadcast);
+  tcase_add_test(tc, test_basic_collapse);
   suite_add_tcase(s, tc);
   return s;
 }

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -1,0 +1,89 @@
+#include <check.h>
+
+#include <gpuarray/buffer.h>
+#include <gpuarray/array.h>
+#include <gpuarray/elemwise.h>
+#include <gpuarray/error.h>
+#include <gpuarray/types.h>
+
+extern void *ctx;
+extern const gpuarray_buffer_ops *ops;
+
+void setup(void);
+void teardown(void);
+
+#define ga_assert_ok(e) ck_assert_int_eq(e, GA_NO_ERROR)
+
+
+START_TEST(test_contig_simple)
+{
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+
+  GpuElemwise *ge;
+
+  static const uint32_t data1[3] = {1, 2, 3};
+  static const uint32_t data2[3] = {4, 5, 6};
+  uint32_t data3[3] = {0};
+
+  size_t dims[1];
+
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
+  dims[0] = 3;
+
+  ga_assert_ok(GpuArray_empty(&a, ops, ctx, GA_FLOAT, 1, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  ga_assert_ok(GpuArray_empty(&b, ops, ctx, GA_FLOAT, 1, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_FLOAT, 1, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].nd = 1;
+  args[0].typecode = GA_FLOAT;
+  args[0].flags = GE_READ;
+
+  args[1].name = "b";
+  args[1].nd = 1;
+  args[1].typecode = GA_FLOAT;
+  args[1].flags = GE_READ;
+
+  args[2].name = "c";
+  args[2].nd = 1;
+  args[2].typecode = GA_FLOAT;
+  args[2].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &b;
+  rargs[2] = &c;
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_BROADCAST));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], 5);
+  ck_assert_int_eq(data3[1], 7);
+  ck_assert_int_eq(data3[2], 9);
+}
+END_TEST
+
+Suite *get_suite(void) {
+  Suite *s = suite_create("elemwise");
+  TCase *tc = tcase_create("contig");
+  tcase_add_checked_fixture(tc, setup, teardown);
+  tcase_add_test(tc, test_contig_simple);
+  suite_add_tcase(s, tc);
+  tc = tcase_create("basic");
+  suite_add_tcase(s, tc);
+  return s;
+}
+
+

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -34,27 +34,27 @@ START_TEST(test_contig_simple)
 
   dims[0] = 3;
 
-  ga_assert_ok(GpuArray_empty(&a, ops, ctx, GA_FLOAT, 1, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_empty(&a, ops, ctx, GA_UINT, 1, dims, GA_C_ORDER));
   ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
 
-  ga_assert_ok(GpuArray_empty(&b, ops, ctx, GA_FLOAT, 1, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_empty(&b, ops, ctx, GA_UINT, 1, dims, GA_C_ORDER));
   ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
 
-  ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_FLOAT, 1, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 1, dims, GA_C_ORDER));
 
   args[0].name = "a";
   args[0].nd = 1;
-  args[0].typecode = GA_FLOAT;
+  args[0].typecode = GA_UINT;
   args[0].flags = GE_READ;
 
   args[1].name = "b";
   args[1].nd = 1;
-  args[1].typecode = GA_FLOAT;
+  args[1].typecode = GA_UINT;
   args[1].flags = GE_READ;
 
   args[2].name = "c";
   args[2].nd = 1;
-  args[2].typecode = GA_FLOAT;
+  args[2].typecode = GA_UINT;
   args[2].flags = GE_WRITE;
 
   ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -65,7 +65,69 @@ START_TEST(test_contig_simple)
   rargs[1] = &b;
   rargs[2] = &c;
 
-  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_BROADCAST));
+  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_NOCOLLAPSE));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], 5);
+  ck_assert_int_eq(data3[1], 7);
+  ck_assert_int_eq(data3[2], 9);
+}
+END_TEST
+
+
+START_TEST(test_basic_simple)
+{
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+
+  GpuElemwise *ge;
+
+  static const uint32_t data1[3] = {1, 2, 3};
+  static const uint32_t data2[3] = {4, 5, 6};
+  uint32_t data3[3] = {0};
+
+  size_t dims[2];
+
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
+  dims[0] = 1;
+  dims[1] = 3;
+
+  ga_assert_ok(GpuArray_empty(&a, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  ga_assert_ok(GpuArray_empty(&b, ops, ctx, GA_UINT, 2, dims, GA_F_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].nd = 2;
+  args[0].typecode = GA_UINT;
+  args[0].flags = GE_READ;
+
+  args[1].name = "b";
+  args[1].nd = 2;
+  args[1].typecode = GA_UINT;
+  args[1].flags = GE_READ;
+
+  args[2].name = "c";
+  args[2].nd = 2;
+  args[2].typecode = GA_UINT;
+  args[2].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &b;
+  rargs[2] = &c;
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_NOCOLLAPSE));
 
   ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
 
@@ -82,6 +144,8 @@ Suite *get_suite(void) {
   tcase_add_test(tc, test_contig_simple);
   suite_add_tcase(s, tc);
   tc = tcase_create("basic");
+  tcase_add_checked_fixture(tc, setup, teardown);
+  tcase_add_test(tc, test_basic_simple);
   suite_add_tcase(s, tc);
   return s;
 }

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -137,6 +137,73 @@ START_TEST(test_basic_simple)
 }
 END_TEST
 
+
+START_TEST(test_basic_remove1)
+{
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+
+  GpuElemwise *ge;
+
+  static const uint32_t data1[6] = {1, 2, 3, 4, 5, 6};
+  static const uint32_t data2[6] = {7, 8, 9, 10, 11, 12};
+  uint32_t data3[6] = {0};
+
+  size_t dims[4];
+
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
+  dims[0] = 1;
+  dims[1] = 3;
+  dims[2] = 2;
+  dims[3] = 1;
+
+  ga_assert_ok(GpuArray_empty(&a, ops, ctx, GA_UINT, 4, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  ga_assert_ok(GpuArray_empty(&b, ops, ctx, GA_UINT, 4, dims, GA_F_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 4, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].nd = 4;
+  args[0].typecode = GA_UINT;
+  args[0].flags = GE_READ;
+
+  args[1].name = "b";
+  args[1].nd = 4;
+  args[1].typecode = GA_UINT;
+  args[1].flags = GE_READ;
+
+  args[2].name = "c";
+  args[2].nd = 4;
+  args[2].typecode = GA_UINT;
+  args[2].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &b;
+  rargs[2] = &c;
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, 0));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], 8);
+  ck_assert_int_eq(data3[1], 12);
+  ck_assert_int_eq(data3[2], 11);
+  ck_assert_int_eq(data3[3], 15);
+  ck_assert_int_eq(data3[4], 14);
+  ck_assert_int_eq(data3[5], 18);
+}
+END_TEST
+
 Suite *get_suite(void) {
   Suite *s = suite_create("elemwise");
   TCase *tc = tcase_create("contig");
@@ -146,6 +213,7 @@ Suite *get_suite(void) {
   tc = tcase_create("basic");
   tcase_add_checked_fixture(tc, setup, teardown);
   tcase_add_test(tc, test_basic_simple);
+  tcase_add_test(tc, test_basic_remove1);
   suite_add_tcase(s, tc);
   return s;
 }

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -43,21 +43,18 @@ START_TEST(test_contig_simple)
   ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 1, dims, GA_C_ORDER));
 
   args[0].name = "a";
-  args[0].nd = 1;
   args[0].typecode = GA_UINT;
   args[0].flags = GE_READ;
 
   args[1].name = "b";
-  args[1].nd = 1;
   args[1].typecode = GA_UINT;
   args[1].flags = GE_READ;
 
   args[2].name = "c";
-  args[2].nd = 1;
   args[2].typecode = GA_UINT;
   args[2].flags = GE_WRITE;
 
-  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 1, 0);
 
   ck_assert_ptr_ne(ge, NULL);
 
@@ -105,21 +102,18 @@ START_TEST(test_basic_simple)
   ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
 
   args[0].name = "a";
-  args[0].nd = 2;
   args[0].typecode = GA_UINT;
   args[0].flags = GE_READ;
 
   args[1].name = "b";
-  args[1].nd = 2;
   args[1].typecode = GA_UINT;
   args[1].flags = GE_READ;
 
   args[2].name = "c";
-  args[2].nd = 2;
   args[2].typecode = GA_UINT;
   args[2].flags = GE_WRITE;
 
-  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 2, 0);
 
   ck_assert_ptr_ne(ge, NULL);
 
@@ -169,21 +163,18 @@ START_TEST(test_basic_remove1)
   ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 4, dims, GA_C_ORDER));
 
   args[0].name = "a";
-  args[0].nd = 4;
   args[0].typecode = GA_UINT;
   args[0].flags = GE_READ;
 
   args[1].name = "b";
-  args[1].nd = 4;
   args[1].typecode = GA_UINT;
   args[1].flags = GE_READ;
 
   args[2].name = "c";
-  args[2].nd = 4;
   args[2].typecode = GA_UINT;
   args[2].flags = GE_WRITE;
 
-  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 4, 0);
 
   ck_assert_ptr_ne(ge, NULL);
 
@@ -240,21 +231,18 @@ START_TEST(test_basic_broadcast)
   ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
 
   args[0].name = "a";
-  args[0].nd = 2;
   args[0].typecode = GA_UINT;
   args[0].flags = GE_READ;
 
   args[1].name = "b";
-  args[1].nd = 2;
   args[1].typecode = GA_UINT;
   args[1].flags = GE_READ;
 
   args[2].name = "c";
-  args[2].nd = 2;
   args[2].typecode = GA_UINT;
   args[2].flags = GE_WRITE;
 
-  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 2, 0);
 
   ck_assert_ptr_ne(ge, NULL);
 
@@ -307,21 +295,18 @@ START_TEST(test_basic_collapse)
   ga_assert_ok(GpuArray_empty(&c, ops, ctx, GA_UINT, 2, dims, GA_C_ORDER));
 
   args[0].name = "a";
-  args[0].nd = 2;
   args[0].typecode = GA_UINT;
   args[0].flags = GE_READ;
 
   args[1].name = "b";
-  args[1].nd = 2;
   args[1].typecode = GA_UINT;
   args[1].flags = GE_READ;
 
   args[2].name = "c";
-  args[2].nd = 2;
   args[2].typecode = GA_UINT;
   args[2].flags = GE_WRITE;
 
-  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 0);
+  ge = GpuElemwise_new(ops, ctx, "", "c = a + b", 3, args, 2, 0);
 
   ck_assert_ptr_ne(ge, NULL);
 

--- a/tests/device.c
+++ b/tests/device.c
@@ -1,0 +1,67 @@
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <check.h>
+
+#include <gpuarray/buffer.h>
+
+int get_env_dev(const gpuarray_buffer_ops **o) {
+  char *dev;
+  char *end;
+  long no;
+  int d;
+  if ((dev = getenv("GPUARRAY_TEST_DEVICE")) == NULL) {
+    if ((dev = getenv("DEVICE")) == NULL) {
+      *o = gpuarray_get_ops("opencl");
+      return 0; /* opencl0:0 */
+    }
+  }
+  if (strncmp(dev, "cuda", 4) == 0) {
+    *o = gpuarray_get_ops("cuda");
+    if (*o == NULL) return -1;
+    no = strtol(dev + 4, &end, 10);
+    if (end == dev || *end != '\0')
+      return -1;
+    if (no < 0 || no > INT_MAX)
+      return -1;
+    return (int)no;
+  }
+  if (strncmp(dev, "opencl", 6) == 0) {
+    *o = gpuarray_get_ops("opencl");
+    if (*o == NULL) return -1;
+    no = strtol(dev + 6, &end, 10);
+    if (end == dev || *end != ':')
+      return -1;
+    if (no < 0 || no > 32768)
+      return -1;
+    d = (int)no;
+    dev = end;
+    no = strtol(dev + 1, &end, 10);
+    if (end == dev || *end != '\0')
+      return -1;
+    if (no < 0 || no > 32768)
+      return -1;
+    d <<= 16;
+    d |= (int)no;
+    return d;
+  }
+  return -1;
+}
+
+void *ctx;
+const gpuarray_buffer_ops *ops;
+
+void setup(void) {
+  int dev = get_env_dev(&ops);
+  if (dev == -1)
+    ck_abort_msg("Bad test device");
+  ctx = ops->buffer_init(dev, 0, NULL);
+  ck_assert_ptr_ne(ctx, NULL);
+}
+
+void teardown(void) {
+  ops->buffer_deinit(ctx);
+  ctx = NULL;
+  ops = NULL;
+}


### PR DESCRIPTION
This is a C port of the python elemwise code with dimension collapsing and broadcasting.

There are only two major kernel variants (contig and basic) for now, but it is possible to add more if required.

Also possible to add in the future are prepared calls, and direct variant calls.