### PR TITLE
Revert "Make *_fromdata steal the reference to gpudata."

### DIFF
--- a/src/gpuarray/array.h
+++ b/src/gpuarray/array.h
@@ -250,9 +250,7 @@ GPUARRAY_PUBLIC int GpuArray_zeros(GpuArray *a, const gpuarray_buffer_ops *ops,
  * The array will be considered to own the gpudata structure after the
  * call is made and will free it when deallocated.  An error return
  * from this function will deallocate `data`.
- *
- * This steal the reference from data. So this don't increment the
- * refcount of data.
+ * This increment the ref count of gpudata. This seem to contradict the above.
  *
  * \param a the GpuArray structure to initialize.  Content will be
  * ignored so make sure to deallocate any previous array first.

--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -147,6 +147,7 @@ int GpuArray_fromdata(GpuArray *a, const gpuarray_buffer_ops *ops,
   a->ops = ops;
   assert(data != NULL);
   a->data = data;
+  ops->buffer_retain(a->data);
   a->nd = nd;
   a->offset = offset;
   a->typecode = typecode;
@@ -197,6 +198,7 @@ int GpuArray_copy_from_host(GpuArray *a, const gpuarray_buffer_ops *ops,
   if (b == NULL) return err;
 
   err = GpuArray_fromdata(a, ops, b, offset, typecode, nd, dims, strides, 1);
+  ops->buffer_release(b);
   return err;
 }
 
@@ -883,6 +885,7 @@ int GpuArray_transfer(GpuArray *res, const GpuArray *a, void *new_ctx,
 
   err = GpuArray_fromdata(res, new_ops, tmp, a->offset - start, a->typecode,
 			  a->nd, a->dimensions, a->strides, 1);
+  new_ops->buffer_release(tmp);
   return err;
 }
 


### PR DESCRIPTION
This reverts commit 9ff5eec91f3624cdd0c7757848fa109bbfb8f8af.

This cause failure in the daily buildbot of the new back-end in Theano on the DLT.