### PR TITLE
Align allocations to 64 bytes instead of 16.

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -24,7 +24,7 @@
 
 /* No returned allocations will be smaller than this size.
    Also, they will be aligned to this size. */
-#define FRAG_SIZE (16)
+#define FRAG_SIZE (64)
 
 static CUresult err;
 


### PR DESCRIPTION
Apparently that is what cuMemAlloc does and I read the docs wrong.