### PR TITLE
First part of the rework to support a faster extcopy.

### DIFF
--- a/src/gpuarray/array.h
+++ b/src/gpuarray/array.h
@@ -219,8 +219,8 @@ static inline int GpuArray_CHKFLAGS(const GpuArray *a, int flags) {
  * left uninitialized.
  */
 GPUARRAY_PUBLIC int GpuArray_empty(GpuArray *a, const gpuarray_buffer_ops *ops,
-                                  void *ctx, int typecode, unsigned int nd,
-                                  const size_t *dims, ga_order ord);
+                                   gpucontext *ctx, int typecode, unsigned int nd,
+                                   const size_t *dims, ga_order ord);
 
 /**
  * Initialize and allocate a new zero-initialized array.
@@ -241,8 +241,8 @@ GPUARRAY_PUBLIC int GpuArray_empty(GpuArray *a, const gpuarray_buffer_ops *ops,
  * left uninitialized.
  */
 GPUARRAY_PUBLIC int GpuArray_zeros(GpuArray *a, const gpuarray_buffer_ops *ops,
-                                  void *ctx, int typecode, unsigned int nd,
-                                  const size_t *dims, ga_order ord);
+                                   gpucontext *ctx, int typecode, unsigned int nd,
+                                   const size_t *dims, ga_order ord);
 
 /**
  * Initialize and allocate a new array structure from a pre-existing buffer.
@@ -268,17 +268,17 @@ GPUARRAY_PUBLIC int GpuArray_zeros(GpuArray *a, const gpuarray_buffer_ops *ops,
  * is left uninitialized and the provided buffer is deallocated.
  */
 GPUARRAY_PUBLIC int GpuArray_fromdata(GpuArray *a,
-                                     const gpuarray_buffer_ops *ops,
-                                     gpudata *data, size_t offset,
-                                     int typecode, unsigned int nd,
-                                     const size_t *dims,
-                                     const ssize_t *strides, int writeable);
+                                      const gpuarray_buffer_ops *ops,
+                                      gpudata *data, size_t offset,
+                                      int typecode, unsigned int nd,
+                                      const size_t *dims,
+                                      const ssize_t *strides, int writeable);
 
 GPUARRAY_PUBLIC int GpuArray_copy_from_host(GpuArray *a,
-                                           const gpuarray_buffer_ops *ops,
-                                           void *ctx, void *buf, int typecode,
-                                           unsigned int nd, const size_t *dims,
-                                           const ssize_t *strides);
+                                            const gpuarray_buffer_ops *ops,
+                                            gpucontext *ctx, void *buf, int typecode,
+                                            unsigned int nd, const size_t *dims,
+                                            const ssize_t *strides);
 
 /**
  * Initialize an array structure to provide a view of another.
@@ -464,7 +464,7 @@ GPUARRAY_PUBLIC int GpuArray_share(const GpuArray *a, const GpuArray *b);
  *
  * \returns the context in which `a` was allocated.
  */
-GPUARRAY_PUBLIC void *GpuArray_context(const GpuArray *a);
+GPUARRAY_PUBLIC gpucontext *GpuArray_context(const GpuArray *a);
 
 /**
  * Copies all the elements of and array to another.
@@ -491,7 +491,7 @@ GPUARRAY_PUBLIC int GpuArray_move(GpuArray *dst, const GpuArray *src);
  * \return an error code otherwise
  */
 GPUARRAY_PUBLIC int GpuArray_write(GpuArray *dst, const void *src,
-                                  size_t src_sz);
+                                   size_t src_sz);
 
 /**
  * Copy data from the device memory to the host memory.
@@ -548,9 +548,9 @@ GPUARRAY_PUBLIC int GpuArray_copy(GpuArray *res, const GpuArray *a,
  * \return an error code otherwise
  */
 GPUARRAY_PUBLIC int GpuArray_transfer(GpuArray *res, const GpuArray *a,
-                                     void *new_ctx,
-                                     const gpuarray_buffer_ops *new_ops,
-                                     int may_share);
+                                      gpucontext *new_ctx,
+                                      const gpuarray_buffer_ops *new_ops,
+                                      int may_share);
 
 /**
  * Split an array into multiple views.

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -38,7 +38,7 @@ struct _gpudata;
 typedef struct _gpucontext {
   GPUCONTEXT_HEAD;
   void *ctx_ptr;
-  void *private[7];
+  void *_private[7];
 } gpucontext;
 
 

--- a/src/gpuarray/buffer_blas.h
+++ b/src/gpuarray/buffer_blas.h
@@ -33,8 +33,8 @@ typedef enum _cb_uplo {
 } cb_uplo;
 
 typedef struct _gpuarray_blas_ops {
-  int (*setup)(void *ctx);
-  void (*teardown)(void *ctx);
+  int (*setup)(gpucontext *ctx);
+  void (*teardown)(gpucontext *ctx);
   int (*hgemv)(cb_order order, cb_transpose transA, size_t M, size_t N,
                float alpha, gpudata *A, size_t offA, size_t lda,
                gpudata *X, size_t offX, int incX, float beta,

--- a/src/gpuarray/elemwise.h
+++ b/src/gpuarray/elemwise.h
@@ -68,7 +68,7 @@ typedef struct _gpuelemwise_arg {
 } gpuelemwise_arg;
 
 GPUARRAY_PUBLIC GpuElemwise *GpuElemwise_new(const gpuarray_buffer_ops *ops,
-                                             void * ctx,
+                                             gpucontext *ctx,
                                              const char *preamble,
                                              const char *expr,
                                              unsigned int n,

--- a/src/gpuarray/ext_cuda.h
+++ b/src/gpuarray/ext_cuda.h
@@ -11,10 +11,9 @@
 extern "C" {
 #endif
 
-static void (*cuda_enter)(void *);
-static void (*cuda_exit)(void *);
-static void *(*cuda_make_ctx)(CUcontext, int);
-static CUcontext (*cuda_get_ctx)(void *);
+static void (*cuda_enter)(gpucontext *);
+static void (*cuda_exit)(gpucontext *);
+static gpucontext *(*cuda_make_ctx)(CUcontext, int);
 static CUstream (*cuda_get_stream)(void *);
 static gpudata *(*cuda_make_buf)(void *, CUdeviceptr, size_t);
 static CUdeviceptr (*cuda_get_ptr)(gpudata *);
@@ -24,10 +23,9 @@ static int (*cuda_record)(gpudata *, int);
 
 static void setup_ext_cuda(void) {
   // The casts are necessary to reassure C++ compilers
-  cuda_enter = (void (*)(void *))gpuarray_get_extension("cuda_enter");
-  cuda_exit = (void (*)(void *))gpuarray_get_extension("cuda_exit");
-  cuda_make_ctx = (void *(*)(CUcontext, int))gpuarray_get_extension("cuda_make_ctx");
-  cuda_get_ctx = (CUcontext (*)(void *))gpuarray_get_extension("cuda_get_ctx");
+  cuda_enter = (void (*)(gpucontext *))gpuarray_get_extension("cuda_enter");
+  cuda_exit = (void (*)(gpucontext *))gpuarray_get_extension("cuda_exit");
+  cuda_make_ctx = (gpucontext *(*)(CUcontext, int))gpuarray_get_extension("cuda_make_ctx");
   cuda_get_stream = (CUstream (*)(void *))gpuarray_get_extension("cuda_get_stream");
   cuda_make_buf = (gpudata *(*)(void *, CUdeviceptr, size_t))gpuarray_get_extension("cuda_make_buf");
   cuda_get_ptr = (CUdeviceptr (*)(gpudata *))gpuarray_get_extension("cuda_get_ptr");

--- a/src/gpuarray/kernel.h
+++ b/src/gpuarray/kernel.h
@@ -55,10 +55,10 @@ typedef struct _GpuKernel {
  * \return any other value if an error occured
  */
 GPUARRAY_PUBLIC int GpuKernel_init(GpuKernel *k, const gpuarray_buffer_ops *ops,
-                                  void *ctx, unsigned int count,
-                                  const char **strs, const size_t *lens,
-                                  const char *name, unsigned int argcount,
-                                  const int *types, int flags, char **err_str);
+                                   gpucontext *ctx, unsigned int count,
+                                   const char **strs, const size_t *lens,
+                                   const char *name, unsigned int argcount,
+                                   const int *types, int flags, char **err_str);
 
 /**
  * Clear and release data associated with a kernel.
@@ -74,7 +74,7 @@ GPUARRAY_PUBLIC void GpuKernel_clear(GpuKernel *k);
  *
  * \returns a context pointer
  */
-GPUARRAY_PUBLIC void *GpuKernel_context(GpuKernel *k);
+GPUARRAY_PUBLIC gpucontext *GpuKernel_context(GpuKernel *k);
 
 
 GPUARRAY_PUBLIC int GpuKernel_setarg(GpuKernel *k, unsigned int i, void *val);

--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -55,7 +55,7 @@ static void ga_boundaries(size_t *start, size_t *end, size_t offset,
 /* Value below which a size_t multiplication will never overflow. */
 #define MUL_NO_OVERFLOW (1UL << (sizeof(size_t) * 4))
 
-int GpuArray_empty(GpuArray *a, const gpuarray_buffer_ops *ops, void *ctx,
+int GpuArray_empty(GpuArray *a, const gpuarray_buffer_ops *ops, gpucontext *ctx,
 		   int typecode, unsigned int nd, const size_t *dims,
                    ga_order ord) {
   size_t size = gpuarray_get_elsize(typecode);
@@ -124,7 +124,7 @@ int GpuArray_empty(GpuArray *a, const gpuarray_buffer_ops *ops, void *ctx,
   return GA_NO_ERROR;
 }
 
-int GpuArray_zeros(GpuArray *a, const gpuarray_buffer_ops *ops, void *ctx,
+int GpuArray_zeros(GpuArray *a, const gpuarray_buffer_ops *ops, gpucontext *ctx,
                    int typecode, unsigned int nd, const size_t *dims,
                    ga_order ord) {
   int err;
@@ -169,7 +169,7 @@ int GpuArray_fromdata(GpuArray *a, const gpuarray_buffer_ops *ops,
 }
 
 int GpuArray_copy_from_host(GpuArray *a, const gpuarray_buffer_ops *ops,
-                            void *ctx, void *buf, int typecode,
+                            gpucontext *ctx, void *buf, int typecode,
                             unsigned int nd, const size_t *dims,
                             const ssize_t *strides) {
   char *base = (char *)buf;
@@ -309,7 +309,7 @@ int GpuArray_index(GpuArray *r, const GpuArray *a, const ssize_t *starts,
 }
 
 static int gen_take1_kernel(GpuKernel *k, const gpuarray_buffer_ops *ops,
-                            void *ctx, char **err_str,
+                            gpucontext *ctx, char **err_str,
                             GpuArray *a, const GpuArray *v,
                             const GpuArray *ind, int addr32) {
   strb sb = STRB_STATIC_INIT;
@@ -807,8 +807,8 @@ int GpuArray_share(const GpuArray *a, const GpuArray *b) {
   return a->ops->buffer_share(a->data, b->data, NULL);
 }
 
-void *GpuArray_context(const GpuArray *a) {
-  void *res = NULL;
+gpucontext *GpuArray_context(const GpuArray *a) {
+  gpucontext *res = NULL;
   (void)a->ops->property(NULL, a->data, NULL, GA_BUFFER_PROP_CTX, &res);
   return res;
 }
@@ -873,7 +873,7 @@ int GpuArray_copy(GpuArray *res, const GpuArray *a, ga_order order) {
   return err;
 }
 
-int GpuArray_transfer(GpuArray *res, const GpuArray *a, void *new_ctx,
+int GpuArray_transfer(GpuArray *res, const GpuArray *a, gpucontext *new_ctx,
                       const gpuarray_buffer_ops *new_ops, int may_share) {
   size_t start, end;
   gpudata *tmp;
@@ -1018,7 +1018,7 @@ int GpuArray_concatenate(GpuArray *r, const GpuArray **as, size_t n,
 }
 
 const char *GpuArray_error(const GpuArray *a, int err) {
-  void *ctx;
+  gpucontext *ctx;
   int err2 = a->ops->property(NULL, a->data, NULL, GA_BUFFER_PROP_CTX, &ctx);
   if (err2 != GA_NO_ERROR) {
     /* If CUDA refuses to work after any kind of error in kernels

--- a/src/gpuarray_blas_cuda_cublas.c
+++ b/src/gpuarray_blas_cuda_cublas.c
@@ -160,7 +160,7 @@ static const char *code_dgerBH_gen_small =                              \
   "  }"                                                                 \
   "}\n";
 
-static int setup(void *c) {
+static int setup(gpucontext *c) {
   cuda_context *ctx = (cuda_context *)c;
   blas_handle *handle;
   const char *tmp[2];
@@ -201,17 +201,17 @@ static int setup(void *c) {
   types[6] = GA_SIZE;
   types[7] = GA_SIZE;
   types[8] = GA_SIZE;
-  e = GpuKernel_init(&handle->sgemvBH_N_a1_b1_small, &cuda_ops, ctx, 1, &code_sgemvBH_N_a1_b1_small, NULL, "sgemv", 9, types, 0, NULL);
+  e = GpuKernel_init(&handle->sgemvBH_N_a1_b1_small, &cuda_ops, c, 1, &code_sgemvBH_N_a1_b1_small, NULL, "sgemv", 9, types, 0, NULL);
   if (e != GA_NO_ERROR) goto e1;
-  e = GpuKernel_init(&handle->sgemvBH_T_a1_b1_small, &cuda_ops, ctx, 1, &code_sgemvBH_T_a1_b1_small, NULL, "sgemv", 9, types, 0, NULL);
+  e = GpuKernel_init(&handle->sgemvBH_T_a1_b1_small, &cuda_ops, c, 1, &code_sgemvBH_T_a1_b1_small, NULL, "sgemv", 9, types, 0, NULL);
   if (e != GA_NO_ERROR) goto e2;
   tmp[0] = atomicadd_double;
   tmp[1] = code_dgemvBH_N_a1_b1_small;
-  e = GpuKernel_init(&handle->dgemvBH_N_a1_b1_small, &cuda_ops, ctx, 2, tmp, NULL, "dgemv", 9, types, GA_USE_DOUBLE, NULL);
+  e = GpuKernel_init(&handle->dgemvBH_N_a1_b1_small, &cuda_ops, c, 2, tmp, NULL, "dgemv", 9, types, GA_USE_DOUBLE, NULL);
   if (e != GA_NO_ERROR) goto e3;
   tmp[0] = atomicadd_double;
   tmp[1] = code_dgemvBH_T_a1_b1_small;
-  e = GpuKernel_init(&handle->dgemvBH_T_a1_b1_small, &cuda_ops, ctx, 2, tmp, NULL, "dgemv", 9, types, GA_USE_DOUBLE, NULL);
+  e = GpuKernel_init(&handle->dgemvBH_T_a1_b1_small, &cuda_ops, c, 2, tmp, NULL, "dgemv", 9, types, GA_USE_DOUBLE, NULL);
   if (e != GA_NO_ERROR) goto e4;
 
   types[0] = GA_BUFFER;
@@ -224,12 +224,12 @@ static int setup(void *c) {
   types[7] = GA_SIZE;
   types[8] = GA_SIZE;
   types[9] = GA_SIZE;
-  e = GpuKernel_init(&handle->sgerBH_gen_small, &cuda_ops, ctx, 1, &code_sgerBH_gen_small, NULL, "_sgerBH_gen_small", 10, types, 0, NULL);
+  e = GpuKernel_init(&handle->sgerBH_gen_small, &cuda_ops, c, 1, &code_sgerBH_gen_small, NULL, "_sgerBH_gen_small", 10, types, 0, NULL);
   if (e != GA_NO_ERROR) goto e5;
   types[4] = GA_DOUBLE;
   tmp[0] = atomicadd_double;
   tmp[1] = code_dgerBH_gen_small;
-  e = GpuKernel_init(&handle->dgerBH_gen_small, &cuda_ops, ctx, 2, tmp, NULL, "_dgerBH_gen_small", 10, types, GA_USE_DOUBLE, NULL);
+  e = GpuKernel_init(&handle->dgerBH_gen_small, &cuda_ops, c, 2, tmp, NULL, "_dgerBH_gen_small", 10, types, GA_USE_DOUBLE, NULL);
   if (e != GA_NO_ERROR) goto e6;
 
   ctx->blas_handle = handle;
@@ -255,7 +255,7 @@ static int setup(void *c) {
   return e;
 }
 
-static void teardown(void *c) {
+static void teardown(gpucontext *c) {
   cuda_context *ctx = (cuda_context *)c;
   blas_handle *handle = (blas_handle *)ctx->blas_handle;
 
@@ -898,17 +898,17 @@ static int sgemvBatch(cb_order order, cb_transpose transA,
       y_l[i] = (float *)(y[i]->ptr + offY[i]);
     }
 
-    Aa = cuda_ops.buffer_alloc(ctx, sizeof(float *) * batchCount, A_l,
+    Aa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(float *) * batchCount, A_l,
                                GA_BUFFER_INIT, &err);
     if (Aa == NULL)
       return err;
-    xa = cuda_ops.buffer_alloc(ctx, sizeof(float *) * batchCount, x_l,
+    xa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(float *) * batchCount, x_l,
                                GA_BUFFER_INIT, &err);
     if (xa == NULL) {
       cuda_ops.buffer_release(Aa);
       return err;
     }
-    ya = cuda_ops.buffer_alloc(ctx, sizeof(float *) * batchCount, y_l,
+    ya = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(float *) * batchCount, y_l,
                                GA_BUFFER_INIT, &err);
     if (ya == NULL) {
       cuda_ops.buffer_release(Aa);
@@ -1022,17 +1022,17 @@ static int dgemvBatch(cb_order order, cb_transpose transA,
       y_l[i] = (double *)(y[i]->ptr + offY[i]);
     }
 
-    Aa = cuda_ops.buffer_alloc(ctx, sizeof(double *) * batchCount, A_l,
+    Aa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(double *) * batchCount, A_l,
                                GA_BUFFER_INIT, &err);
     if (Aa == NULL)
       return err;
-    xa = cuda_ops.buffer_alloc(ctx, sizeof(double *) * batchCount, x_l,
+    xa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(double *) * batchCount, x_l,
                                GA_BUFFER_INIT, &err);
     if (xa == NULL) {
       cuda_ops.buffer_release(Aa);
       return err;
     }
-    ya = cuda_ops.buffer_alloc(ctx, sizeof(double *) * batchCount, y_l,
+    ya = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(double *) * batchCount, y_l,
                                GA_BUFFER_INIT, &err);
     if (ya == NULL) {
       cuda_ops.buffer_release(Aa);
@@ -1277,17 +1277,17 @@ static int sgerBatch(cb_order order, size_t M, size_t N, float alpha,
       y_l[i] = (float *)(y[i]->ptr + offY[i]);
     }
 
-    Aa = cuda_ops.buffer_alloc(ctx, sizeof(float *) * batchCount, A_l,
+    Aa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(float *) * batchCount, A_l,
                                GA_BUFFER_INIT, &err);
     if (Aa == NULL)
       return err;
-    xa = cuda_ops.buffer_alloc(ctx, sizeof(float *) * batchCount, x_l,
+    xa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(float *) * batchCount, x_l,
                                GA_BUFFER_INIT, &err);
     if (xa == NULL) {
       cuda_ops.buffer_release(Aa);
       return err;
     }
-    ya = cuda_ops.buffer_alloc(ctx, sizeof(float *) * batchCount, y_l,
+    ya = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(float *) * batchCount, y_l,
                                GA_BUFFER_INIT, &err);
     if (ya == NULL) {
       cuda_ops.buffer_release(Aa);
@@ -1409,17 +1409,17 @@ static int dgerBatch(cb_order order, size_t M, size_t N, double alpha,
       y_l[i] = (double *)(y[i]->ptr + offY[i]);
     }
 
-    Aa = cuda_ops.buffer_alloc(ctx, sizeof(double *) * batchCount, A_l,
+    Aa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(double *) * batchCount, A_l,
                                GA_BUFFER_INIT, &err);
     if (Aa == NULL)
       return err;
-    xa = cuda_ops.buffer_alloc(ctx, sizeof(double *) * batchCount, x_l,
+    xa = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(double *) * batchCount, x_l,
                                GA_BUFFER_INIT, &err);
     if (xa == NULL) {
       cuda_ops.buffer_release(Aa);
       return err;
     }
-    ya = cuda_ops.buffer_alloc(ctx, sizeof(double *) * batchCount, y_l,
+    ya = cuda_ops.buffer_alloc((gpucontext *)ctx, sizeof(double *) * batchCount, y_l,
                                GA_BUFFER_INIT, &err);
     if (ya == NULL) {
       cuda_ops.buffer_release(Aa);

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -72,7 +72,7 @@ static void free_args(unsigned int n, gpuelemwise_arg *args) {
 
 static int gen_elemwise_basic_kernel(GpuKernel *k,
                                      const gpuarray_buffer_ops *ops,
-                                     void *ctx, char **err_str,
+                                     gpucontext *ctx, char **err_str,
                                      const char *preamble,
                                      const char *expr,
                                      unsigned int nd,
@@ -383,7 +383,7 @@ static int call_basic(GpuElemwise *ge, void **args, size_t n, unsigned int nd,
 
 static int gen_elemwise_contig_kernel(GpuKernel *k,
                                       const gpuarray_buffer_ops *ops,
-                                      void *ctx, char **err_str,
+                                      gpucontext *ctx, char **err_str,
                                       const char *preamble,
                                       const char *expr,
                                       unsigned int n,
@@ -525,7 +525,7 @@ static int call_contig(GpuElemwise *ge, void **args, size_t n) {
   return GpuKernel_call(&ge->k_contig, 1, &ls, &gs, 0, NULL);
 }
 
-GpuElemwise *GpuElemwise_new(const gpuarray_buffer_ops *ops, void * ctx,
+GpuElemwise *GpuElemwise_new(const gpuarray_buffer_ops *ops, gpucontext *ctx,
                              const char *preamble, const char *expr,
                              unsigned int n, gpuelemwise_arg *args,
                              unsigned int nd, int flags) {

--- a/src/gpuarray_extension.c
+++ b/src/gpuarray_extension.c
@@ -11,7 +11,6 @@ typedef struct _ext {
 extern void cuda_enter(void);
 extern void cuda_exit(void);
 extern void *cuda_make_ctx(void);
-extern void *cuda_get_ctx(void);
 extern void *cuda_get_stream(void);
 extern void *cuda_make_buf(void);
 extern void *cuda_get_sz(void);
@@ -20,7 +19,6 @@ extern void *cuda_record(void);
 #endif
 #ifdef WITH_OPENCL
 extern void *cl_make_ctx(void);
-extern void *cl_get_ctx(void);
 extern void *cl_get_stream(void);
 extern void *cl_make_buf(void);
 extern void *cl_get_buf(void);
@@ -31,7 +29,6 @@ static ext ext_list[] = {
   {"cuda_enter", cuda_enter},
   {"cuda_exit", cuda_exit},
   {"cuda_make_ctx", cuda_make_ctx},
-  {"cuda_get_ctx", cuda_get_ctx},
   {"cuda_get_stream", cuda_get_stream},
   {"cuda_make_buf", cuda_make_buf},
   {"cuda_get_sz", cuda_get_sz},
@@ -40,7 +37,6 @@ static ext ext_list[] = {
 #endif
 #ifdef WITH_OPENCL
   {"cl_make_ctx", cl_make_ctx},
-  {"cl_get_ctx", cl_get_ctx},
   {"cl_get_stream", cl_get_stream},
   {"cl_make_buf", cl_make_buf},
   {"cl_get_buf", cl_get_buf},

--- a/src/gpuarray_kernel.c
+++ b/src/gpuarray_kernel.c
@@ -4,7 +4,7 @@
 
 #include <stdlib.h>
 
-int GpuKernel_init(GpuKernel *k, const gpuarray_buffer_ops *ops, void *ctx,
+int GpuKernel_init(GpuKernel *k, const gpuarray_buffer_ops *ops, gpucontext *ctx,
                    unsigned int count, const char **strs, const size_t *lens,
                    const char *name, unsigned int argcount, const int *types,
                    int flags, char **err_str) {
@@ -30,8 +30,8 @@ void GpuKernel_clear(GpuKernel *k) {
   k->args = NULL;
 }
 
-void *GpuKernel_context(GpuKernel *k) {
-  void *res = NULL;
+gpucontext *GpuKernel_context(GpuKernel *k) {
+  gpucontext *res = NULL;
   (void)k->ops->property(NULL, NULL, k->k, GA_KERNEL_PROP_CTX, &res);
   return res;
 }
@@ -104,7 +104,7 @@ int GpuKernel_binary(const GpuKernel *k, size_t *sz, void **bin) {
 }
 
 const char *GpuKernel_error(const GpuKernel *k, int err) {
-  void *ctx;
+  gpucontext *ctx;
   int err2 = k->ops->property(NULL, NULL, k->k, GA_KERNEL_PROP_CTX, &ctx);
   if (err2 != GA_NO_ERROR) {
     /* If CUDA refuses to work after any kind of error in kernels

--- a/src/private.h
+++ b/src/private.h
@@ -25,6 +25,8 @@ extern "C" {
 #define SADDR32_MIN -2147483648
 #define SADDR32_MAX  2147483647
 
+#define STATIC_ASSERT(COND, MSG) typedef char static_assertion_##MSG[2*(!!(COND))-1]
+
 static inline void *memdup(const void *p, size_t s) {
   void *res = malloc(s);
   if (res != NULL)

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -76,9 +76,8 @@ STATIC_ASSERT(sizeof(cuda_context) <= sizeof(gpucontext), sizeof_struct_gpuconte
 #define ARCH_PREFIX "sm_"
 #endif
 
-GPUARRAY_LOCAL void *cuda_make_ctx(CUcontext ctx, int flags);
-GPUARRAY_LOCAL CUcontext cuda_get_ctx(void *ctx);
-GPUARRAY_LOCAL CUstream cuda_get_stream(void *ctx);
+GPUARRAY_LOCAL cuda_context *cuda_make_ctx(CUcontext ctx, int flags);
+GPUARRAY_LOCAL CUstream cuda_get_stream(cuda_context *ctx);
 GPUARRAY_LOCAL void cuda_enter(cuda_context *ctx);
 GPUARRAY_LOCAL void cuda_exit(cuda_context *ctx);
 
@@ -96,7 +95,7 @@ struct _gpudata {
 #endif
 };
 
-GPUARRAY_LOCAL gpudata *cuda_make_buf(void *c, CUdeviceptr p, size_t sz);
+GPUARRAY_LOCAL gpudata *cuda_make_buf(cuda_context *c, CUdeviceptr p, size_t sz);
 GPUARRAY_LOCAL CUdeviceptr cuda_get_ptr(gpudata *g);
 GPUARRAY_LOCAL size_t cuda_get_sz(gpudata *g);
 GPUARRAY_LOCAL int cuda_wait(gpudata *, int);

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -41,25 +41,19 @@
 /* Keep in sync with the copy in gpuarray/extension.h */
 #define DONTFREE 0x10000000
 
-#define BIN_ID_LEN 12
-
 typedef struct _cuda_context {
-#ifdef DEBUG
-  char tag[8];
-#endif
+  GPUCONTEXT_HEAD;
   CUcontext ctx;
   CUresult err;
   CUstream s;
   CUstream mem_s;
-  void *blas_handle;
-  gpudata *errbuf;
   cache *extcopy_cache;
-  char bin_id[BIN_ID_LEN];
-  unsigned int refcnt;
-  int flags;
-  unsigned int enter;
   gpudata *freeblocks;
+  unsigned int enter;
 } cuda_context;
+
+STATIC_ASSERT(sizeof(cuda_context) <= sizeof(gpucontext), sizeof_struct_gpucontext_cuda);
+
 
 /*
  * About freeblocks.

--- a/src/private_opencl.h
+++ b/src/private_opencl.h
@@ -35,18 +35,14 @@
 #endif
 
 typedef struct _cl_ctx {
-#ifdef DEBUG
-  char tag[8];
-#endif
+  GPUCONTEXT_HEAD;
   cl_context ctx;
   cl_command_queue q;
   char *exts;
-  void *blas_handle;
-  gpudata *errbuf;
   cl_int err;
-  unsigned int refcnt;
-  char bin_id[64];
 } cl_ctx;
+
+STATIC_ASSERT(sizeof(cl_ctx) <= sizeof(gpucontext), sizeof_struct_gpucontext_cl);
 
 struct _gpudata {
   cl_mem buf;
@@ -73,9 +69,8 @@ struct _gpukernel {
 };
 
 GPUARRAY_LOCAL cl_ctx *cl_make_ctx(cl_context ctx);
-GPUARRAY_LOCAL cl_context cl_get_ctx(void *ctx);
-GPUARRAY_LOCAL cl_command_queue cl_get_stream(void *ctx);
-GPUARRAY_LOCAL gpudata *cl_make_buf(void *c, cl_mem buf);
+GPUARRAY_LOCAL cl_command_queue cl_get_stream(gpucontext *ctx);
+GPUARRAY_LOCAL gpudata *cl_make_buf(gpucontext *c, cl_mem buf);
 GPUARRAY_LOCAL cl_mem cl_get_buf(gpudata *g);
 
 #endif


### PR DESCRIPTION
This creates a struct gpucontext which holds part of the information for the gpu context.

There are no ABI changes for compiled programs since the old struct was opaque anyway and it is still handled everywhere as a pointer.  But now it allows us to add things that are shared for all contexts (such as a GpuElemwise instance).

There is no such change yet as this is mostly a sweeping rename to make sure nothing broke at this step.