### PR TITLE
float16 support for  GpuElemwise

### DIFF
--- a/src/gpuarray/elemwise.h
+++ b/src/gpuarray/elemwise.h
@@ -114,6 +114,11 @@ GPUARRAY_PUBLIC GpuElemwise *GpuElemwise_new(gpucontext *ctx,
 #define GE_NOADDR64    0x0001
 
 /**
+ * Convert float16 inputs to float32 for computation.
+ */
+#define GE_CONVERT_F16 0x0002
+
+/**
  * @}
  */
 

--- a/src/gpuarray_util.c
+++ b/src/gpuarray_util.c
@@ -14,7 +14,7 @@
  * there.
  */
 const int gpuarray_api_major = -9997;
-const int gpuarray_api_minor = 0;
+const int gpuarray_api_minor = 1;
 
 static gpuarray_type **custom_types = NULL;
 static int n_types = 0;

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -12,7 +12,7 @@ void setup(void);
 void teardown(void);
 
 #define ga_assert_ok(e) ck_assert_int_eq(e, GA_NO_ERROR)
-/* float 16 table */
+/* float 16 table (0 through 10) */
 static const uint16_t F16[10] = {0x0000, 0x3c00, 0x4000, 0x4200, 0x4400, 0x4500, 0x4600, 0x4700, 0x4800, 0x4880};
 
 

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -12,6 +12,9 @@ void setup(void);
 void teardown(void);
 
 #define ga_assert_ok(e) ck_assert_int_eq(e, GA_NO_ERROR)
+/* float 16 table */
+static const uint16_t F16[10] = {0x0000, 0x3c00, 0x4000, 0x4200, 0x4400, 0x4500, 0x4600, 0x4700, 0x4800, 0x4880};
+
 
 
 START_TEST(test_contig_simple)
@@ -72,6 +75,70 @@ START_TEST(test_contig_simple)
 END_TEST
 
 
+START_TEST(test_contig_f16)
+{
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+
+  GpuElemwise *ge;
+
+  static uint16_t data1[3];
+  data1[0] = F16[1];
+  data1[1] = F16[2];
+  data1[2] = F16[3];
+  static uint16_t data2[3];
+  data2[0] = F16[4];
+  data2[1] = F16[5];
+  data2[2] = F16[6];
+  uint16_t data3[3] = {0};
+
+  size_t dims[1];
+
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
+  dims[0] = 3;
+
+  ga_assert_ok(GpuArray_empty(&a, ctx, GA_HALF, 1, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  ga_assert_ok(GpuArray_empty(&b, ctx, GA_HALF, 1, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  ga_assert_ok(GpuArray_empty(&c, ctx, GA_HALF, 1, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].typecode = GA_HALF;
+  args[0].flags = GE_READ;
+
+  args[1].name = "b";
+  args[1].typecode = GA_HALF;
+  args[1].flags = GE_READ;
+
+  args[2].name = "c";
+  args[2].typecode = GA_HALF;
+  args[2].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ctx, "", "c = a + b", 3, args, 1, GE_CONVERT_F16);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &b;
+  rargs[2] = &c;
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_NOCOLLAPSE));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], F16[5]);
+  ck_assert_int_eq(data3[1], F16[7]);
+  ck_assert_int_eq(data3[2], F16[9]);
+}
+END_TEST
+
+
 START_TEST(test_basic_simple)
 {
   GpuArray a;
@@ -127,6 +194,71 @@ START_TEST(test_basic_simple)
   ck_assert_int_eq(data3[0], 5);
   ck_assert_int_eq(data3[1], 7);
   ck_assert_int_eq(data3[2], 9);
+}
+END_TEST
+
+
+START_TEST(test_basic_f16)
+{
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+
+  GpuElemwise *ge;
+
+  static uint16_t data1[3];
+  data1[0] = F16[1];
+  data1[1] = F16[2];
+  data1[2] = F16[3];
+  static uint16_t data2[3];
+  data2[0] = F16[4];
+  data2[1] = F16[5];
+  data2[2] = F16[6];
+  uint16_t data3[3] = {0};
+
+  size_t dims[2];
+
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
+  dims[0] = 1;
+  dims[1] = 3;
+
+  ga_assert_ok(GpuArray_empty(&a, ctx, GA_HALF, 2, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  ga_assert_ok(GpuArray_empty(&b, ctx, GA_HALF, 2, dims, GA_F_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  ga_assert_ok(GpuArray_empty(&c, ctx, GA_HALF, 2, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].typecode = GA_HALF;
+  args[0].flags = GE_READ;
+
+  args[1].name = "b";
+  args[1].typecode = GA_HALF;
+  args[1].flags = GE_READ;
+
+  args[2].name = "c";
+  args[2].typecode = GA_HALF;
+  args[2].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ctx, "", "c = a + b", 3, args, 2, GE_CONVERT_F16);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &b;
+  rargs[2] = &c;
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_NOCOLLAPSE));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], F16[5]);
+  ck_assert_int_eq(data3[1], F16[7]);
+  ck_assert_int_eq(data3[2], F16[9]);
 }
 END_TEST
 
@@ -399,13 +531,16 @@ END_TEST
 Suite *get_suite(void) {
   Suite *s = suite_create("elemwise");
   TCase *tc = tcase_create("contig");
+  tcase_set_timeout(tc, 8.0);
   tcase_add_checked_fixture(tc, setup, teardown);
   tcase_add_test(tc, test_contig_simple);
+  tcase_add_test(tc, test_contig_f16);
   suite_add_tcase(s, tc);
   tc = tcase_create("basic");
   tcase_set_timeout(tc, 8.0);
   tcase_add_checked_fixture(tc, setup, teardown);
   tcase_add_test(tc, test_basic_simple);
+  tcase_add_test(tc, test_basic_f16);
   tcase_add_test(tc, test_basic_remove1);
   tcase_add_test(tc, test_basic_broadcast);
   tcase_add_test(tc, test_basic_collapse);


### PR DESCRIPTION
This enable support for float16 in elemwise operations by performing the computation in float32.

This behaviour will only be active if the GE_CONVERT_F16 flags is passed when creating the GpuElemwise object.

It does not make GPUs which don't have even the most basic support for float16 work since those don't have either the data types or the conversion primitives that we need.  On the cuda side it should mostly always work, but on OpenCL your device needs to support the cl_khr_fp16 extension (which notably NVIDIA and most CPU vendors chose not to enable).