### PR TITLE
Add missing cuStreamDestroy a context's memory stream

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -128,6 +128,7 @@ static void cuda_free_ctx(cuda_context *ctx) {
     cuMemFreeHost((void *)ctx->errbuf->ptr);
     deallocate(ctx->errbuf);
 
+    cuStreamDestroy(ctx->mem_s);
     cuStreamDestroy(ctx->s);
 
     /* Clear out the freelist */


### PR DESCRIPTION
This will add `cuStreamDestroy(ctx->mem_s)` in `static void cuda_free_ctx(cuda_context *ctx)` as discussed [here](https://groups.google.com/forum/#!topic/theano-dev/pRuqbclL_Cw).