### PR TITLE
Add a shortcut to cuda_waits() in case we are on the same stream.

### DIFF
--- a/pygpu/gpuarray.pxd
+++ b/pygpu/gpuarray.pxd
@@ -81,6 +81,7 @@ cdef extern from "gpuarray/buffer.h":
     int GA_CTX_DEFAULT
     int GA_CTX_MULTI_THREAD
     int GA_CTX_SINGLE_THREAD
+    int GA_CTX_SINGLE_STREAM
     int GA_CTX_DISABLE_ALLOCATION_CACHE
 
     int GA_CTX_PROP_DEVNAME

--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -498,9 +498,9 @@ cdef GpuContext pygpu_init(dev, int flags):
         raise ValueError, "Unknown device format:" + dev
     return GpuContext(kind, devnum, flags)
 
-def init(dev, sched='default', disable_alloc_cache=False):
+def init(dev, sched='default', disable_alloc_cache=False, single_stream=False):
     """
-    init(dev, opt='default', disable_alloc_cache=False)
+    init(dev, opt='default', disable_alloc_cache=False, single_stream=False)
 
     Creates a context from a device specifier.
 
@@ -510,6 +510,8 @@ def init(dev, sched='default', disable_alloc_cache=False):
     :type sched: {'default', 'single', 'multi'}
     :param disable_alloc_cache: disable allocation cache (if any)
     :type disable_alloc_cache: bool
+    :param single_stream: enable single stream mode
+    :type single_stream: bool
     :rtype: GpuContext
 
     Device specifiers are composed of the type string and the device
@@ -535,8 +537,8 @@ def init(dev, sched='default', disable_alloc_cache=False):
     expected_version = -9997
     if gpuarray_api_major != expected_version or gpuarray_api_minor < 0:
         raise RuntimeError(
-            "Pygpu was expecting libgpuarray version %d, but %d is available "
-            " Recompile it to avoid problems.",
+            "Pygpu was expecting libgpuarray version %d, but %d is available. "
+            "Recompile it to avoid problems.",
             expected_version, gpuarray_api_major)
     if sched == 'single':
         flags |= GA_CTX_SINGLE_THREAD
@@ -546,6 +548,8 @@ def init(dev, sched='default', disable_alloc_cache=False):
         raise TypeError('unexpected value for parameter sched: %s' % (sched,))
     if disable_alloc_cache:
         flags |= GA_CTX_DISABLE_ALLOCATION_CACHE
+    if single_stream:
+        flags |= GA_CTX_SINGLE_STREAM
     return pygpu_init(dev, flags)
 
 def zeros(shape, dtype=GA_DOUBLE, order='C', GpuContext context=None,

--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -500,7 +500,7 @@ cdef GpuContext pygpu_init(dev, int flags):
 
 def init(dev, sched='default', disable_alloc_cache=False, single_stream=False):
     """
-    init(dev, opt='default', disable_alloc_cache=False, single_stream=False)
+    init(dev, sched='default', disable_alloc_cache=False, single_stream=False)
 
     Creates a context from a device specifier.
 

--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -37,13 +37,13 @@ def cl_wrap_ctx(size_t ptr):
     Wrap an existing OpenCL context (the cl_context struct) into a
     GpuContext class.
     """
-    cdef gpucontext *(*cl_make_ctx)(void *)
+    cdef gpucontext *(*cl_make_ctx)(void *, int)
     cdef GpuContext res
-    cl_make_ctx = <gpucontext *(*)(void *)>gpuarray_get_extension("cl_make_ctx")
+    cl_make_ctx = <gpucontext *(*)(void *, int)>gpuarray_get_extension("cl_make_ctx")
     if cl_make_ctx == NULL:
         raise RuntimeError, "cl_make_ctx extension is absent"
     res = GpuContext.__new__(GpuContext)
-    res.ctx = cl_make_ctx(<void *>ptr)
+    res.ctx = cl_make_ctx(<void *>ptr, 0)
     if res.ctx == NULL:
         raise RuntimeError, "cl_make_ctx call failed"
     return res

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -90,7 +90,7 @@ GPUARRAY_PUBLIC gpucontext *gpucontext_init(const char *name, int dev,
 #define GA_CTX_SINGLE_THREAD 0x02
 
 /**
- * Perform all operations in the order they appear.
+ * Allocate a single stream per context, performing all operations in order.
  *
  * This will remove any attempt at exploiting parallelism in the
  * underlying device by performing unrelated operations concurrently
@@ -98,7 +98,7 @@ GPUARRAY_PUBLIC gpucontext *gpucontext_init(const char *name, int dev,
  *
  * This can help performance by removing the small cost paid for each
  * operation to keep everything coherent in the face of parallelism.
- * It can also hinder performance by doing everything one after the other.
+ * It can also hinder performance by not exploiting concurrency.
  */
 #define GA_CTX_SINGLE_STREAM 0x4
 

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -90,6 +90,19 @@ GPUARRAY_PUBLIC gpucontext *gpucontext_init(const char *name, int dev,
 #define GA_CTX_SINGLE_THREAD 0x02
 
 /**
+ * Perform all operations in the order they appear.
+ *
+ * This will remove any attempt at exploiting parallelism in the
+ * underlying device by performing unrelated operations concurrently
+ * and/or out of order.
+ *
+ * This can help performance by removing the small cost paid for each
+ * operation to keep everything coherent in the face of parallelism.
+ * It can also hinder performance by doing everything one after the other.
+ */
+#define GA_CTX_SINGLE_STREAM 0x4
+
+/**
  * Disable allocations cache (if any).
  *
  * This will usually decrease performance by quite a bit, but will

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -449,8 +449,7 @@ static int extract(gpudata *curr, gpudata *prev, size_t size) {
     split->next = curr->next;
     curr->next = NULL;
     /* Make sure we don't start using the split buffer too soon */
-    cuda_wait(curr, CUDA_WAIT_ALL);
-    cuda_record(split, CUDA_WAIT_ALL);
+    cuda_records(split, CUDA_WAIT_ALL, curr->ls);
     next = split;
     curr->sz = size;
   }
@@ -563,8 +562,8 @@ static void cuda_free(gpudata *d) {
       if (!(d->flags & CUDA_HEAD_ALLOC) &&
             prev != NULL && prev->ptr + prev->sz == d->ptr) {
         prev->sz = prev->sz + d->sz;
-        cuda_wait(d, CUDA_WAIT_ALL);
-        cuda_record(prev, CUDA_WAIT_ALL);
+        cuda_waits(d, CUDA_WAIT_ALL, prev->ls);
+        cuda_records(prev, CUDA_WAIT_ALL, prev->ls);
         deallocate(d);
         d = prev;
       } else if (prev != NULL) {

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -67,6 +67,8 @@ cuda_context *cuda_make_ctx(CUcontext ctx, int flags) {
   if (detect_arch(ARCH_PREFIX, res->bin_id, &err)) {
     goto fail_stream;
   }
+  /* Don't add the nonblocking flags to help usage with other
+     libraries that may do stuff on the NULL stream */
   err = cuStreamCreate(&res->s, 0);
   if (err != CUDA_SUCCESS) {
     goto fail_stream;
@@ -74,6 +76,8 @@ cuda_context *cuda_make_ctx(CUcontext ctx, int flags) {
   if (ISSET(res->flags, GA_CTX_SINGLE_STREAM)) {
     res->mem_s = res->s;
   } else {
+    /* Don't add the nonblocking flags to help usage with other
+       libraries that may do stuff on the NULL stream */
     err = cuStreamCreate(&res->mem_s, 0);
     if (err != CUDA_SUCCESS) {
       goto fail_mem_stream;

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -88,6 +88,7 @@ struct _gpudata {
      struct _partial_gpudata */
   CUevent rev;
   CUevent wev;
+  CUstream ls; /* last stream used */
   unsigned int refcnt;
   int flags;
   size_t sz;

--- a/src/private_opencl.h
+++ b/src/private_opencl.h
@@ -70,7 +70,7 @@ struct _gpukernel {
 #endif
 };
 
-GPUARRAY_LOCAL cl_ctx *cl_make_ctx(cl_context ctx);
+GPUARRAY_LOCAL cl_ctx *cl_make_ctx(cl_context ctx, int flags);
 GPUARRAY_LOCAL cl_command_queue cl_get_stream(gpucontext *ctx);
 GPUARRAY_LOCAL gpudata *cl_make_buf(gpucontext *c, cl_mem buf);
 GPUARRAY_LOCAL cl_mem cl_get_buf(gpudata *g);


### PR DESCRIPTION
This helps lower the overhead of cuda_wait() for the single-stream case.