### PR TITLE
Update the cython requirement.

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -24,7 +24,7 @@ Requirements
  - (optional) libcheck (check_) to run the C tests.
  - (optional) python (python_) for the python bindings.
  - (optional) mako (mako_) for development or running the python bindings.
- - (optional) Cython >= 0.19 (cython_) for the python bindings.
+ - (optional) Cython >= 0.21 (cython_) for the python bindings.
  - (optional) nosetests (nosetests_) to run the python tests.
 
 .. note::

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ have_cython = False
 
 try:
     import Cython
-    if Cython.__version__ < '0.19':
+    if Cython.__version__ < '0.21':
         raise Exception('cython is too old or not installed '
-                        '(at least 0.19 required)')
+                        '(at least 0.21 required)')
     from Cython.Build import cythonize
     have_cython = True
 except Exception:


### PR DESCRIPTION
fix #194. It made me realize that we require cython 0.21 minimum to build so this updates the docs to reflect that.