### PR TITLE
allow concatenate and split to take a negative axis

### DIFF
--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -1733,7 +1733,7 @@ cdef class GpuArray:
         if sz == 1:
             return bool(numpy.asarray(self))
         else:
-            raise ValueError, "Thruth value of array with more than one element is ambiguous"
+            raise ValueError, "Truth value of array with more than one element is ambiguous"
 
     property shape:
         "shape of this ndarray (tuple)"

--- a/pygpu/operations.py
+++ b/pygpu/operations.py
@@ -81,6 +81,8 @@ def array_split(ary, indices_or_sections, axis=0):
     except TypeError:
         if axis < 0:
             axis += ary.ndim
+        if axis < 0:
+            raise ValueError('axis out of bounds')
         nsec = int(indices_or_sections)
         if nsec <= 0:
             raise ValueError('number of sections must be larger than 0.')
@@ -121,6 +123,8 @@ def concatenate(arys, axis=0, context=None):
                          "impossible")
     if axis < 0:
         axis += arys[0].ndim
+    if axis < 0:
+        raise ValueError('axis out of bounds')
     al = [asarray(a, context=context) for a in arys]
     if context is None:
         context = al[0].context

--- a/pygpu/operations.py
+++ b/pygpu/operations.py
@@ -79,6 +79,8 @@ def array_split(ary, indices_or_sections, axis=0):
         indices = list(indices_or_sections)
         res = _split(ary, indices, axis)
     except TypeError:
+        if axis < 0:
+            axis += ary.ndim
         nsec = int(indices_or_sections)
         if nsec <= 0:
             raise ValueError('number of sections must be larger than 0.')
@@ -117,6 +119,8 @@ def concatenate(arys, axis=0, context=None):
     if len(arys) == 0:
         raise ValueError("concatenation of zero-length sequences is "
                          "impossible")
+    if axis < 0:
+        axis += arys[0].ndim
     al = [asarray(a, context=context) for a in arys]
     if context is None:
         context = al[0].context

--- a/pygpu/tests/test_operations.py
+++ b/pygpu/tests/test_operations.py
@@ -13,6 +13,14 @@ def test_array_split():
     for pc, pg in zip(rc, rg):
         numpy.testing.assert_allclose(pc, numpy.asarray(pg))
 
+    xc, xg = gen_gpuarray((8,), 'float32', ctx=context)
+    rc = numpy.array_split(xc, 3, axis=-1)
+    rg = pygpu.array_split(xg, 3, axis=-1)
+
+    assert len(rc) == len(rg)
+    for pc, pg in zip(rc, rg):
+        numpy.testing.assert_allclose(pc, numpy.asarray(pg))
+
 def test_split():
     for spl in (3, [3, 5, 6, 10]):
         yield xsplit, '', (9,), spl
@@ -47,6 +55,11 @@ def test_concatenate():
 
     rc = numpy.concatenate((ac, bc.T), axis=1)
     rg = pygpu.concatenate((ag, bg.T), axis=1)
+
+    numpy.testing.assert_allclose(rc, numpy.asarray(rg))
+
+    rc = numpy.concatenate((ac, bc.T), axis=-1)
+    rg = pygpu.concatenate((ag, bg.T), axis=-1)
 
     numpy.testing.assert_allclose(rc, numpy.asarray(rg))
 


### PR DESCRIPTION
numpy's concatenate and split allow axis to be a negative number. Since _concatenate and _split take an unsigned int, it seemed that the best place to make this change was in operations.concatenate and operations.array_split.