### PR TITLE
Allow reduction kernels to do broadcasting

### DIFF
--- a/pygpu/reduction.py
+++ b/pygpu/reduction.py
@@ -235,12 +235,15 @@ class ReductionKernel(object):
         return self._find_kernel_ls(self._gen_basic, maxls, nd)
 
     def __call__(self, *args, **kwargs):
-        _, nd, dims, strs, offsets = check_args(args, collapse=False,
-                                                broadcast=False)
+        broadcast = kwargs.pop('broadcast', None)
         out = kwargs.pop('out', None)
         if len(kwargs) != 0:
             raise TypeError('Unexpected keyword argument: %s' %
                             kwargs.keys()[0])
+
+        _, nd, dims, strs, offsets = check_args(args, collapse=False,
+                                                broadcast=broadcast)
+
         n = prod(dims)
         out_shape = tuple(d for i, d in enumerate(dims) if not self.redux[i])
         gs = prod(out_shape)
@@ -248,7 +251,7 @@ class ReductionKernel(object):
             gs = 1
         n /= gs
         if gs > self.context.maxgsize:
-            raise ValueError("Array to big to be reduced along the "
+            raise ValueError("Array too big to be reduced along the "
                              "selected axes")
 
         if out is None:


### PR DESCRIPTION
I'm unsure whether you want this, but it seems useful to me to allow a call to a ReductionKernel to take a broadcast=True argument. For example, if a = [[1,2,3]] and b = [[4,5,6], [7,8,9]], in NumPy we can write sum(a*b, axis=-1) to get [32,50], and the attached change allows a reduction kernel to do the same.

Possible issue: maybe broadcasting on the reduction axis is not useful. The attached change allows this, but maybe it should be disallowed.
