### PR TITLE
round allocation size to power of two times BLOCK_SIZE

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -400,8 +400,12 @@ static int allocate(cuda_context *ctx, gpudata **res, gpudata **prev,
   gpudata *next;
   *prev = NULL;
 
-  if (!(ctx->flags & GA_CTX_DISABLE_ALLOCATION_CACHE))
-    if (size < BLOCK_SIZE) size = BLOCK_SIZE;
+  if (!(ctx->flags & GA_CTX_DISABLE_ALLOCATION_CACHE)) {
+    /* Round block size up to nearest power of two times BLOCK_SIZE */
+    size_t new_size = BLOCK_SIZE;
+    while (new_size < size) new_size *= 2;
+    size = new_size;
+  }
 
   cuda_enter(ctx);
 


### PR DESCRIPTION
If a block of size (say) 10M is allocated, then a block of 11M, then the previous 10M block can't be used; this change rounds up to a power of two times BLOCK_SIZE to alleviate this problem a bit.
