### PR TITLE
Local memory support for OpenCL kernels

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -282,7 +282,9 @@ static const char CUDA_PREAMBLE[] =
     "#define ga_size size_t\n"
     "#define ga_ssize ptrdiff_t\n"
     "#define load_half(p) __half2float(*(p))\n"
-    "#define store_half(p, v) (*(p) = __float2half_rn(v))\n";
+    "#define store_half(p, v) (*(p) = __float2half_rn(v))\n"
+    "#define GA_DECL_SHARED_PARAM(type, name)\n"
+    "#define GA_DECL_SHARED_BODY(type, name) extern __shared__ type name[];\n";
 
 /* XXX: add complex, quads, longlong */
 /* XXX: add vector types */

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -198,6 +198,9 @@ static const char CL_PREAMBLE[] =
   "#define LOCAL_MEM __local\n"
   "#define LOCAL_MEM_ARG __local\n"
   "#define REQD_WG_SIZE(x, y, z) __attribute__((reqd_work_group_size(x, y, z)))\n"
+  "#ifndef NULL\n"
+  "  #define NULL ((void*)0)\n"
+  "#endif\n"
   "#define LID_0 get_local_id(0)\n"
   "#define LID_1 get_local_id(1)\n"
   "#define LID_2 get_local_id(2)\n"
@@ -225,7 +228,9 @@ static const char CL_PREAMBLE[] =
   "#define ga_size ulong\n"
   "#define ga_ssize long\n"
   "#define load_half(p) vload_half(0, p)\n"
-  "#define store_half(p, v) vstore_half_rtn(v, 0, p)\n";
+  "#define store_half(p, v) vstore_half_rtn(v, 0, p)\n"
+  "#define GA_DECL_SHARED_PARAM(type, name) , __local type name[]\n"
+  "#define GA_DECL_SHARED_BODY(type, name)\n";
 
 /* XXX: add complex types, quad types, and longlong */
 /* XXX: add vector types */
@@ -918,9 +923,6 @@ static int cl_callkernel(gpukernel *k, unsigned int n,
   if (n > 3)
     return GA_VALUE_ERROR;
 
-  if (shared != 0)
-    return GA_UNSUPPORTED_ERROR;
-
   dev = get_dev(ctx->ctx, &res);
   if (dev == NULL) return res;
 
@@ -929,6 +931,12 @@ static int cl_callkernel(gpukernel *k, unsigned int n,
       err = cl_setkernelarg(k, i, args[i]);
       if (err != GA_NO_ERROR) return err;
     }
+  }
+
+  if (shared != 0) {
+    // the shared memory pointer must be the last argument
+    ctx->err = clSetKernelArg(k->k, k->argcount, shared, NULL);
+    if (ctx->err != CL_SUCCESS) return GA_IMPL_ERROR;
   }
 
   evw = calloc(sizeof(cl_event), k->argcount);


### PR DESCRIPTION
Currently libgpuarray does not support dynamic shared (local) memory for OpenCL. Function cl_callkernel() simply returns `GA_UNSUPPORTED_ERROR` when the paremeter "shared" is non-zero. Since dynamic local memory is important to implement many kernels (like cumsum) in Theano, I am trying to add local memory support to libgpuarray and thus we can have more OpenCL functionality in Theano.

Since OpenCL needs a different syntax than CUDA for dynamic shared memory, it is not easy to implement this using libgpuarray's existing macro based "compatibility layer" for CUDA and OpenCL. In CUDA, we define a dynamic shared memory like the following:

`
extern __shared__ float shared_variable[];`

And then we give cuLauchKernel a size parameter to allocate this shared memory array.

In OpenCL, a dynamic shared (local) memory array must be passed as a parameter of the kernel, and the size of local memory is specified by clSetKernelArg(). Since the ways of declaring a dynamic shared array are at different places, it seems impossible to use a single macro to hide this language-dependent detail. Another alternative is to provide different kernels for CUDA and OpenCL in Theano, but it will make OpenCL kernel implementation and maintenance much harder.

I am trying to deal with this problem using a simple solution. This solution won't affect any existing code. I added two more preamble macros in gpuarray_buffer_opencl.c and gpuarray_buffer_cuda.c, `GA_DECL_SHARED_PARAM(type, name)` and `GA_DECL_SHARED_BODY(type, name)`. Both macros must be used to declare a dynamic shared array, in the following way:

```
KERNEL void my_kernel(type1 param1, type2 param2, ...
			// GA_DECL_SHARED_PARAM must be the last parameter
                      GA_DECL_SHARED_PARAM(type, shared_variable_name))
{
	// declare the shared variable again in the function body
	GA_DECL_SHARED_BODY(type, shared_variable_name);
}

```
`GA_DECL_SHARED_PARAM` must follow the last argument, and this macro will turn into an empty macro if we generate CUDA code. When generating OpenCL code it is transformed to a pointer to local memory. Similarly, `GA_DECL_SHARED_BODY` turns into empty if we generate OpenCL code, and when generating CUDA code it is transformed to an extern'ed pointer to shared memory. We only need to support one (not multiple) dynamic shared memory array (in fact, CUDA only supports one dynamic shared memory array), and if more arrays are needed some pointer tricks can be used.

And this is the way of writing the blockCumSum kernel:

```
KERNEL void k_blockCumSum(GLOBAL_MEM float* input, GLOBAL_MEM float* output,
                                ga_size nbElementsPerCumsum, ga_ssize inputStrides_x,
                                ga_ssize inputStrides_y,  ga_ssize inputStrides_z,
                                ga_ssize outputStrides_x, ga_ssize outputStrides_y,
                                ga_ssize outputStrides_z, int offsetY,
                                int offsetZ, GLOBAL_MEM float* blockSum
                                GA_DECL_SHARED_PARAM(float, partialCumSum)) {
    // Regarding blockIdx and threadIdx, 'Cumsum' is always performed along the X axis.
    // The Y and Z axis of the grid will contain all independent cumsums of the 2D/3D case.

    int globalThreadID = GID_0 * LDIM_0 + LID_0;

    // Check if current thread has data to process.
    if (globalThreadID >= ceil(nbElementsPerCumsum/2.0)) {
        return;
    }

    // extern __shared__ float partialCumSum[];
    GA_DECL_SHARED_BODY(float, partialCumSum);

    // Load data in shared memory
    k_fetchData(partialCumSum, input, globalThreadID, inputStrides_x, inputStrides_y, inputStrides_z, offsetY, offsetZ);
    
    // Remaining function body...
}

```