### PR TITLE
Check if src == dst in cl_move() and avoid double event release

### DIFF
--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -497,7 +497,7 @@ static int cl_move(gpudata *dst, size_t dstoff, gpudata *src, size_t srcoff,
 
   if (src->ev != NULL)
     evw[num_ev++] = src->ev;
-  if (dst->ev != NULL)
+  if (dst->ev != NULL && src != dst)
     evw[num_ev++] = dst->ev;
 
   if (num_ev > 0)
@@ -510,7 +510,7 @@ static int cl_move(gpudata *dst, size_t dstoff, gpudata *src, size_t srcoff,
   }
   if (src->ev != NULL)
     clReleaseEvent(src->ev);
-  if (dst->ev != NULL)
+  if (dst->ev != NULL && src != dst)
     clReleaseEvent(dst->ev);
 
   src->ev = ev;


### PR DESCRIPTION
In cl_move(), we didn't check if src and dst are the same array. If they are in fact the same array (which is allowed), clReleaseEvent() will be called twice for the same event. If the reference counter for that event happens to go 0, it will be deleted. It won't cause an immediately failure, however later clEnqueueCopyBuffer() will be using an invalid (deleted) event, and accessing memory in an unexpected manner.

In my experiments, after passing src==dst to cl_move(), the program will crash (segmentation fault) after some time in some weird places (not inside cl_move or clEnqueueCopyBuffer) with a mysterious message (like "corrupted double-linked list" in glibc, or a segmentation fault inside a completely irrelevant function). This is because clEnqueueCopyBuffer() damaged the heap meta-data when accessing an invalid event.
