### PR TITLE
Add a new preamble macro GA_WARP_SIZE

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -284,7 +284,8 @@ static const char CUDA_PREAMBLE[] =
     "#define load_half(p) __half2float(*(p))\n"
     "#define store_half(p, v) (*(p) = __float2half_rn(v))\n"
     "#define GA_DECL_SHARED_PARAM(type, name)\n"
-    "#define GA_DECL_SHARED_BODY(type, name) extern __shared__ type name[];\n";
+    "#define GA_DECL_SHARED_BODY(type, name) extern __shared__ type name[];\n"
+    "#define GA_WARP_SIZE warpSize\n";
 
 /* XXX: add complex, quads, longlong */
 /* XXX: add vector types */

--- a/src/private_opencl.h
+++ b/src/private_opencl.h
@@ -40,6 +40,7 @@ typedef struct _cl_ctx {
   cl_command_queue q;
   char *exts;
   cl_int err;
+  char *preamble;
 } cl_ctx;
 
 STATIC_ASSERT(sizeof(cl_ctx) <= sizeof(gpucontext), sizeof_struct_gpucontext_cl);

--- a/src/private_opencl.h
+++ b/src/private_opencl.h
@@ -39,8 +39,8 @@ typedef struct _cl_ctx {
   cl_context ctx;
   cl_command_queue q;
   char *exts;
-  cl_int err;
   char *preamble;
+  cl_int err;
 } cl_ctx;
 
 STATIC_ASSERT(sizeof(cl_ctx) <= sizeof(gpucontext), sizeof_struct_gpucontext_cl);


### PR DESCRIPTION
The CUDA runtime constant warpSize is used in a few Theano GPU kernels. This patch defines a new preamble macro, GA_WARP_SIZE, to make kernel code portable between CUDA and OpenCL. In CUDA, it is simply replaced by warpSize; in OpenCL, no such runtime constant is provided; the closet alternative is the kernel property CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE. Technically there are some subtle differences between warpSize and CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, however on GPUs they both reflect the hardware SIMD size. 

Since it depends on the GPU device, the definition of GA_WARP_SIZE in OpenCL preamble has to be created dynamically. I added necessary code to cl_check_extensions() that creates a dummy kernel, gets the GA_KERNEL_PROP_PREFLSIZE property and updates the preamble. We also need to be aware that warpSize is a runtime constant and the defined macro for OpenCL is a compile-time constant, but there will be no difference if we don't reuse _compiled_ kernel binaries on different devices.
