### PR TITLE
GA_USE_HALF workaround for OpenCL

### DIFF
--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -688,11 +688,14 @@ static int cl_check_extensions(const char **preamble, unsigned int *count,
   if (flags & GA_USE_COMPLEX) {
     return GA_DEVSUP_ERROR; // for now
   }
+  // GA_USE_HALF should always work
+  /*
   if (flags & GA_USE_HALF) {
     if (check_ext(ctx, CL_HALF)) return GA_DEVSUP_ERROR;
     preamble[*count] = PRAGMA CL_HALF ENABLE;
     (*count)++;
   }
+  */
   if (flags & GA_USE_CUDA) {
     return GA_DEVSUP_ERROR;
   }


### PR DESCRIPTION
Before we add another flag for indicating half precision arithmetic support on Nvidia Pascal and AMD Polaris, the current flag GA_USE_HALF is used for indicating half precision load and store support and should always pass on OpenCL platforms (like what we did in the CUDA backend), because half precision load and store are part of OpenCL 1.0 specification without any extensions. This allows us to pass all libgpuarray tests on most OpenCL platforms (which do not have cl_khr_fp16), and enables some kernels in Thenao to work with OpenCL. See also issue #218 

In the long run we probably want to make GA_USE_HALF obsoleted and use flags like  GA_USE_HALF_LOADSTORE and GA_USE_HALF_MATH etc.

Without this workaround the following libgpuarry tests failed:

```
$ tests/check_elemwise 
Running suite(s): elemwise
81%: Checks: 11, Failures: 2, Errors: 0
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:71:P:contig:test_contig_simple:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:121:F:contig:test_contig_f16:0: Assertion 'ge != ((void *)0)' failed: ge == 0, ((void *)0) == 0
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:177:P:contig:test_contig_0:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:234:P:basic:test_basic_simple:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:285:F:basic:test_basic_f16:0: Assertion 'ge != ((void *)0)' failed: ge == 0, ((void *)0) == 0
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:361:P:basic:test_basic_offset:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:423:P:basic:test_basic_remove1:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:491:P:basic:test_basic_broadcast:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:551:P:basic:test_basic_collapse:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:620:P:basic:test_basic_neg_strides:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:665:P:basic:test_basic_0:0: Passed
```

And after by passing GA_USE_HALF everything works fine.

```
$ tests/check_elemwise 
Running suite(s): elemwise
100%: Checks: 11, Failures: 0, Errors: 0
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:71:P:contig:test_contig_simple:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:133:P:contig:test_contig_f16:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:177:P:contig:test_contig_0:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:234:P:basic:test_basic_simple:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:297:P:basic:test_basic_f16:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:361:P:basic:test_basic_offset:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:423:P:basic:test_basic_remove1:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:491:P:basic:test_basic_broadcast:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:551:P:basic:test_basic_collapse:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:620:P:basic:test_basic_neg_strides:0: Passed
/home/huan/programs/dl/libgpuarray/tests/check_elemwise.c:665:P:basic:test_basic_0:0: Passed
```

