### PR TITLE
enable to compile in under C99 compiler

### DIFF
--- a/src/gpuarray_array_blas.c
+++ b/src/gpuarray_array_blas.c
@@ -370,6 +370,7 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
   int err;
   gpudata **A_datas = NULL, **B_datas = NULL, **C_datas = NULL;
   size_t *A_offsets = NULL, *B_offsets = NULL, *C_offsets = NULL;
+  int i;
 
   if (A->typecode != GA_FLOAT && A->typecode != GA_DOUBLE)
     return GA_INVALID_ERROR;
@@ -500,7 +501,6 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
   B_offsets = (size_t*)malloc(batchCount * sizeof(size_t));
   C_offsets = (size_t*)malloc(batchCount * sizeof(size_t));
 
-  int i;
   for (i = 0; i < batchCount; i++) {
     A_datas[i] = Ap->data;
     B_datas[i] = Bp->data;

--- a/src/gpuarray_array_collectives.c
+++ b/src/gpuarray_array_collectives.c
@@ -48,9 +48,10 @@ static inline int check_gpuarrays(int times_src, const GpuArray* src,
 
 int GpuArray_reduce_from(const GpuArray* src, int opcode, int root,
                          gpucomm* comm) {
+  size_t total_elems;
   if (!GpuArray_ISALIGNED(src))
     return GA_UNALIGNED_ERROR;
-  size_t total_elems = find_total_elems(src);
+  total_elems = find_total_elems(src);
   return gpucomm_reduce(src->data, src->offset, NULL, 0, total_elems,
                         src->typecode, opcode, root, comm);
 }
@@ -90,6 +91,7 @@ int GpuArray_reduce_scatter(const GpuArray* src, GpuArray* dest, int opcode,
 
 int GpuArray_broadcast(GpuArray* array, int root, gpucomm* comm) {
   int rank = 0;
+  size_t total_elems;
   GA_CHECK(gpucomm_get_rank(comm, &rank));
   if (rank == root) {
     if (!GpuArray_CHKFLAGS(array, GA_BEHAVED))
@@ -99,7 +101,7 @@ int GpuArray_broadcast(GpuArray* array, int root, gpucomm* comm) {
       return GA_UNALIGNED_ERROR;
   }
 
-  size_t total_elems = find_total_elems(array);
+  total_elems = find_total_elems(array);
 
   return gpucomm_broadcast(array->data, array->offset, total_elems,
                            array->typecode, root, comm);

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -718,7 +718,9 @@ static gpukernel *cl_newkernel(gpucontext *c, unsigned int count,
   const char **news = NULL;
   unsigned int n = 0;
   int error;
-
+  strb debug_msg = STRB_STATIC_INIT;
+  size_t log_size;
+  
   ASSERT_CTX(ctx);
 
   if (count == 0) FAIL(NULL, GA_VALUE_ERROR);
@@ -780,12 +782,10 @@ static gpukernel *cl_newkernel(gpucontext *c, unsigned int count,
     if (ctx->err == CL_BUILD_PROGRAM_FAILURE && err_str!=NULL) {
       *err_str = NULL;  // Fallback, in case there's an error
 
-      strb debug_msg = STRB_STATIC_INIT;
       // We're substituting debug_msg for a string with this first line:
       strb_appends(&debug_msg, "Program build failure ::\n");
 
       // Determine the size of the log
-      size_t log_size;
       clGetProgramBuildInfo(p, dev, CL_PROGRAM_BUILD_LOG, 0, NULL, &log_size);
 
       if(strb_ensure(&debug_msg, log_size)!=-1 && log_size>=1) { // Checks strb has enough space


### PR DESCRIPTION
In windows, python 3.4 compiled Visual Studio 2010 and it don't support C99.

This PR enable to compile libgpuarray in VS2015.