### PR TITLE
Internal scheduler with integer arguments + Factorizer improvements + Assorted bugfixes

### DIFF
--- a/src/util/integerfactoring.c
+++ b/src/util/integerfactoring.c
@@ -995,12 +995,22 @@ static int      gaIFactorize5Smooth(uint64_t n, ga_factor_list* fl){
 		}
 
 		for(i3=0, p3=1;i3<=40;i3++, p3*=3){
+			/**
+			 * Detect when the product p3*p5 would overflow 2^64.
+			 */
+
+			if(i3){
+				nCurr = (p3/3)*p5;
+				if(nCurr+nCurr < nCurr || nCurr+nCurr+nCurr < nCurr+nCurr){
+					break;
+				}
+			}
 			nCurr = p3*p5;
 
 			/**
 			 * If the current product of powers of 3 and 5 is >= n, then this
-			 * must be the last iteration, but perhaps a pure power of 3 is the
-			 * best choice, so check for this.
+			 * must be the last iteration, but perhaps a pure product of powers
+			 * of 3 and 5 is the best choice, so check for this.
 			 */
 
 			if(nCurr >= n){

--- a/src/util/integerfactoring.c
+++ b/src/util/integerfactoring.c
@@ -254,7 +254,7 @@ static uint64_t gaIAvgMod    (uint64_t a, uint64_t b, uint64_t m){
 }
 
 static uint64_t gaIMulMod    (uint64_t a, uint64_t b, uint64_t m){
-#if (__GNUC__ >= 4) && defined(__x86_64__)
+#if (__GNUC__ >= 4) && defined(__x86_64__) && !defined(__STRICT_ANSI__)
 	uint64_t r;
 
 	asm(

--- a/src/util/integerfactoring.c
+++ b/src/util/integerfactoring.c
@@ -12,6 +12,10 @@
 #endif
 
 
+/* Defines */
+#define GA_IS_COMPOSITE      0
+#define GA_IS_PRIME          1
+#define GA_IS_PROBABLY_PRIME 2
 
 
 /**
@@ -37,6 +41,42 @@ static int      gaICtz(uint64_t n);
 static int      gaIClz(uint64_t n);
 
 /**
+ * @brief Integer Modular Addition.
+ * 
+ * Computes
+ * 
+ *     $$a+b \pmod m$$
+ * 
+ * efficiently for 64-bit unsigned integers a, b, m.
+ */
+
+static uint64_t gaIAddMod    (uint64_t a, uint64_t b, uint64_t m);
+
+/**
+ * @brief Integer Modular Subtraction.
+ * 
+ * Computes
+ * 
+ *     $$a-b \pmod m$$
+ * 
+ * efficiently for 64-bit unsigned integers a, b, m.
+ */
+
+static uint64_t gaISubMod    (uint64_t a, uint64_t b, uint64_t m);
+
+/**
+ * @brief Integer Modular Average.
+ * 
+ * Computes
+ * 
+ *     $$\frac{a+b}{2} \pmod m$$
+ * 
+ * efficiently for 64-bit unsigned integers a, b, m.
+ */
+
+static uint64_t gaIAvgMod    (uint64_t a, uint64_t b, uint64_t m);
+
+/**
  * @brief Integer Modular Multiplication.
  *
  * Computes
@@ -59,6 +99,40 @@ static uint64_t gaIMulMod    (uint64_t a, uint64_t b, uint64_t m);
  */
 
 static uint64_t gaIPowMod    (uint64_t x, uint64_t a, uint64_t m);
+
+/**
+ * @brief Jacobi Symbol
+ * 
+ * Computes the Jacobi symbol, notated
+ * 
+ *     $$(a/n)$$
+ * 
+ * efficiently for 64-bit unsigned integers a, n.
+ */
+
+static int      gaIJacobiSymbol(uint64_t a, uint64_t n);
+
+/**
+ * @brief Strong Fermat base-a probable prime test.
+ * 
+ * @param [in] n  An odd integer >= 3.
+ * @param [in] a  A witness integer > 0.
+ * @return Non-zero if n is a strong probable prime to base a and zero if n is
+ *         composite.
+ */
+
+static int      gaIIsPrimeStrongFermat(uint64_t n, uint64_t a);
+
+/**
+ * @brief Strong Lucas probable prime test.
+ * 
+ * The function uses Selfridge's Method A for selecting D,P,Q.
+ * 
+ * @param [in] n  An odd integer >= 3.
+ * @return Non-zero if n is a strong probable prime and zero if n is composite.
+ */
+
+static int      gaIIsPrimeStrongLucas(uint64_t n);
 
 /**
  * @brief Round up positive n to next 2-, 3- or 5-smooth number and report its
@@ -134,6 +208,38 @@ static int      gaIClz       (uint64_t n){
 #endif
 }
 
+static uint64_t gaIAddMod    (uint64_t a, uint64_t b, uint64_t m){
+	a %= m;
+	b %= m;
+	
+	if(m-a > b){
+		return a+b;
+	}else{
+		return a+b-m;
+	}
+}
+
+static uint64_t gaISubMod    (uint64_t a, uint64_t b, uint64_t m){
+	a %= m;
+	b %= m;
+	
+	if(a >= b){
+		return a-b;
+	}else{
+		return a-b+m;
+	}
+}
+
+static uint64_t gaIAvgMod    (uint64_t a, uint64_t b, uint64_t m){
+	uint64_t s = gaIAddMod(a,b,m);
+	
+	if(s&1){
+		return (s>>1)+(m>>1)+(s&m&1);
+	}else{
+		return s>>1;
+	}
+}
+
 static uint64_t gaIMulMod    (uint64_t a, uint64_t b, uint64_t m){
 #if (__GNUC__ >= 4) && defined(__x86_64__)
 	uint64_t r;
@@ -141,8 +247,8 @@ static uint64_t gaIMulMod    (uint64_t a, uint64_t b, uint64_t m){
 	asm(
 	    "mul %2\n\t"
 	    "div %3\n\t"
-	    : "=&d"(r)                 /* Outputs */
-	    : "a"(a), "r"(b), "r"(m)   /* Inputs */
+	    : "=&d"(r), "+a"(a)   /* Outputs */
+	    : "r"(b),  "r"(m)     /* Inputs */
 	    : "cc"
 	);
 
@@ -267,25 +373,254 @@ static uint64_t gaIPowMod    (uint64_t x, uint64_t a, uint64_t m){
 	return r;
 }
 
-int      gaIIsPrime   (uint64_t n){
-	size_t         i, j;
-	int            hasNoSmallFactors, hasSmallFactors;
-	uint64_t       r, d;
-	const uint64_t WITNESSES[]  = {2,3,5,7,11,13,17,19,23,29,31,37};
-	const int      NUMWITNESSES = sizeof(WITNESSES)/sizeof(WITNESSES[0]);
+static int      gaIJacobiSymbol(uint64_t a, uint64_t n){
+	int      s=0;
+	uint64_t e, a1, n1;
+	
+	a %= n;
+	
+	if(a == 1 || n == 1){
+		return 1;
+	}
+	
+	if(a == 0){
+		return 0;
+	}
+	
+	e  = gaICtz(a);
+	a1 = a >> e;
+	
+	if(e%2 == 0){
+		s =  1;
+	}else if(n%8 == 1 || n%8 == 7){
+		s =  1;
+	}else if(n%8 == 3 || n%8 == 5){
+		s = -1;
+	}
+	
+	if(n%4 == 3 && a1%4 == 3){
+		s = -s;
+	}
+	
+	n1 = n%a1;
+	return s*gaIJacobiSymbol(n1,a1);
+}
 
+static int      gaIIsPrimeStrongFermat(uint64_t n, uint64_t a){
+	/**
+	 * The Fermat strong probable prime test the Miller-Rabin test relies upon
+	 * uses integer "witnesses" in an attempt at proving the number composite.
+	 * Should it fail to prove an integer composite, it reports the number as
+	 * "probably prime". However, if the witnesses are chosen carefully, the
+	 * Miller-Rabin test can be made deterministic below a chosen threshold.
+	 * 
+	 * One can use the primes 2 to 37 in order to ensure the correctness of the
+	 * identifications for integers under 2^64.
+	 * 
+	 * Jim Sinclair has found that the seven witnesses
+	 *     2, 325, 9375, 28178, 450775, 9780504, 1795265022
+	 * also deterministically classify all integers <2^64.
+	 * 
+	 * 
+	 * The Fermat strong probable prime test states that, for integers
+	 *             n = d*2^s+1,  d odd, s integer >= 0
+	 *             a             integer (chosen witness)
+	 * n is a Fermat strong probable prime if
+	 *     a^(d    ) =  1 mod n       or
+	 *     a^(d*2^r) = -1 mod n       for any integer r, 0 <= r < s.
+	 * 
+	 * 
+	 * The justification for this comes from Fermat's Little Theorem: If n is
+	 * prime and a is any integer, then the following always holds:
+	 *           a^n =  a mod n
+	 * If n is prime and a is coprime to n, then the following always holds:
+	 *       a^(n-1) =  1 mod n
+	 * 
+	 * 
+	 * In effect, the logic goes
+	 * 
+	 *   A:   The number  n  is prime.                               (Statement)
+	 *   B:   The number  n  does not divide a.                      (Statement)
+	 *   C:   a^(  n-1)       =  1 mod n                             (Statement)
+	 *   D:   The commutative ring Z/nZ is a finite field.           (Statement)
+	 *   E:   Finite fields are unique factorization domains.        (Statement)
+	 *   F:   x^2 = 1 mod n factorizes as (x+1)(x-1) = 0 mod n.      (Statement)
+	 *   G:   x^2 mod n only has the trivial square roots 1 and -1   (Statement)
+	 *   H:   The number  n  is odd and >= 3.                        (Statement)
+	 *   I:   The number n-1 equals d*2^s, with d,s int > 0, d odd.  (Statement)
+	 *   J:   a^(    d)       =   1 mod n                            (Statement)
+	 *   K:   a^(d*2^r)       =  -1 mod n   for some 0 <= r < s.     (Statement)
+	 *   L:   a^(d*2^(r+1))   =   1 mod n   for some 0 <= r < s.     (Statement)
+	 *   M:   a^(d*2^r)      != +-1 mod n   AND                      (Statement)
+	 *        a^(d*2^(r+1))   =   1 mod n   for some 0 <= r < s.
+	 *   
+	 *   A&B           -->  C                 (Proposition:     Fermat's Little Theorem)
+	 *   !C            -->  !(A&B) = !A|!B    (Contrapositive:  Fermat's Little Theorem)
+	 *   A             <->  D                 (Proposition)
+	 *   E                                    (Proposition:     By definition)
+	 *   F                                    (Proposition:     x^2-x+x-1 = x^2-1 mod n)
+	 *   D&E&F         -->  G                 (Proposition:     (x+1)(x-1) is the only
+	 *                                                           factorization)
+	 *   !G            -->  !D|!E|!F          (Contrapositive:  See above)
+	 *   H&I&J         -->  C                 (Proposition:     Squaring  1 gives 1)
+	 *   H&I&K         -->  L                 (Proposition:     Squaring -1 gives 1)
+	 *   H&I&L         -->  C                 (Proposition:     1, squared or not, gives 1)
+	 *   H&I&K         -->  C                 (Hypothetical Syllogism)
+	 *   H&I&(J|K)     -->  C                 (Union)
+	 *   H&I&!(J|K)    -->  M|!C              (Proposition:     Either squaring
+	 *                                                            a^(d*2^(s-1)) != +-1 mod n
+	 *                                                          gives a 1, in which case
+	 *                                                          M holds, or it does not
+	 *                                                          give 1 and therefore
+	 *                                                            a^(n-1) != 1 mod n)
+	 *                                                          and thus !C holds.
+	 *   H&I&!(J|K)    -->  H&I&M | !A | !B   (Absorbtion, Hypothetical Syllogism)
+	 *   H&I&M         -->  !G                (Proposition:     x^2 = 1 mod n but x!=+1,
+	 *                                                          so x^2 - 1 has roots
+	 *                                                          other than +-1)
+	 *   H&I&M         -->  !D|!E|!F          (Modus Tollens)
+	 *   H&I&M         -->  !D                (Disjunctive Syllogism)
+	 *   H&I&M         -->  !A                (Biconditional)
+	 *   H&I&!(J|K)    -->  !A | !A | !B      (Hypothethical Syllogism)
+	 *   H&I&!(J|K)&B  -->  !A | !A           (Absorbtion)
+	 *   H&I&!(J|K)&B  -->  !A | !A           (Disjunctive Syllogism)
+	 *   H&I&!(J|K)&B  -->  !A                (Disjunctive Simplification)
+	 *                           ***** Conclusions: *****
+	 *                            H&I&M         -->  !A
+	 *                            H&I&!(J|K)&B  -->  !A
+	 * 
+	 * Broadly speaking, what the above tells us is:
+	 *   - We can't prove n prime (A), but we can prove it composite (!A).
+	 *   - Either H&I&M or H&I&!(J|K)&B prove compositeness.
+	 *   - If H&I&(J|K) for any r, then we've proven C true. If we prove C true,
+	 *     we can't use the contrapositive of Fermat's Little Theorem, so no
+	 *     conclusions about the truth-value of A can be made. The test is
+	 *     inconclusive. Thus this function returns "probably prime".
+	 */
+	
+	uint64_t d, x;
+	int64_t  s, r;
+	
+	a %= n;
+	if(a==0){
+		return GA_IS_PROBABLY_PRIME;
+	}
+	
+	s  = gaICtz(n-1);
+	d  = (n-1) >> s;
+	x  = gaIPowMod(a,d,n);
+	
+	if(x==1 || x==n-1){
+		return GA_IS_PROBABLY_PRIME;
+	}
+	
+	for(r=0;r<s-1;r++){
+		x = gaIMulMod(x,x,n);
+		if(x==1){
+			return GA_IS_COMPOSITE;
+		}else if(x == n-1){
+			return GA_IS_PROBABLY_PRIME;
+		}
+	}
+	
+	return GA_IS_COMPOSITE;
+}
+
+static int      gaIIsPrimeStrongLucas(uint64_t n){
+	uint64_t Dp, Dm, D, K, U, Ut, V, Vt;
+	int      J, r, i;
+	
+	/**
+	 * FIPS 186-4 C.3.3 (General) Lucas Probabilistic Primality Test
+	 * 
+	 * 1. Test if n is perfect square. If so, return "composite".
+	 * 
+	 *     NOTE: The only strong base-2 Fermat pseudoprime squares are
+	 *           1194649 and 12327121;
+	 */
+	
+	if(n==1194649 || n==12327121){
+		return GA_IS_COMPOSITE;
+	}
+	
+	/**
+	 * 2. Find first D in sequence 5,-7,9,-11,... s.t. Jacobi symbol (D/n) < 1.
+	 *     Iff Jacobi symbol is 0, return "composite".
+	 */
+	
+	Dp = gaIAddMod(0, 5, n);
+	Dm = gaISubMod(0, 7, n);
+	while(1){
+		J = gaIJacobiSymbol(Dp, n);
+		if     (J ==  0){return GA_IS_COMPOSITE;}
+		else if(J == -1){D = Dp;break;}
+		
+		J = gaIJacobiSymbol(Dm, n);
+		if     (J ==  0){return GA_IS_COMPOSITE;}
+		else if(J == -1){D = Dm;break;}
+		
+		Dp = gaIAddMod(Dp, 4, n);
+		Dm = gaISubMod(Dm, 4, n);
+	}
+	
+	/**
+	 * 3. K = n+1
+	 * 
+	 *     NOTE: Cannot overflow, since 2^64-1 is eliminated by strong Fermat
+	 *           base-2 test.
+	 */
+	
+	K = n+1;
+	
+	/**
+	 * 4. Let Kr, Kr–1, ..., K0 be the binary expansion of K, with Kr = 1.
+	 */
+	
+	r = 63-gaIClz(K);
+	
+	/**
+	 * 5. Set Ur = 1 and Vr = 1.
+	 */
+	
+	U = V = 1;
+	
+	/**
+	 * 6. For i=r–1 to 0, do
+	 */
+	
+	for(i=r-1;i>=0;i--){
+		Ut = gaIMulMod(U,V,n);
+		Vt = gaIAvgMod(gaIMulMod(V,V,n), gaIMulMod(D,gaIMulMod(U,U,n),n), n);
+		if((K>>i)&1){
+			U = gaIAvgMod(Ut,Vt,n);
+			V = gaIAvgMod(Vt,gaIMulMod(D,Ut,n),n);
+		}else{
+			U = Ut;
+			V = Vt;
+		}
+	}
+	
+	/**
+	 * 7. If U0==0, then return "probably prime". Otherwise, return "composite".
+	 */
+	
+	return U==0 ? GA_IS_PROBABLY_PRIME : GA_IS_COMPOSITE;
+}
+
+int      gaIIsPrime   (uint64_t n){
+	int            hasNoSmallFactors, hasSmallFactors;
 
 	/**
 	 * Check if it is 2, the oddest prime.
 	 */
 
-	if(n==2){return 1;}
+	if(n==2){return GA_IS_PRIME;}
 
 	/**
 	 * Check if it is an even integer.
 	 */
 
-	if((n&1) == 0){return 0;}
+	if((n&1) == 0){return GA_IS_COMPOSITE;}
 
 	/**
 	 * For small integers, read directly the answer in a table.
@@ -306,71 +641,35 @@ int      gaIIsPrime   (uint64_t n){
 	 * Test small prime factors.
 	 */
 
-	hasNoSmallFactors = n%3 && n%5 && n%7 && n%11 && n%13;
+	hasNoSmallFactors = n% 3 && n% 5 && n% 7 && n%11 && n%13 && n%17 && n%19 &&
+	                    n%23 && n%29 && n%31 && n%37 && n%41 && n%43 && n%47 &&
+	                    n%53 && n%59 && n%61 && n%67 && n%71 && n%73 && n%79;
 	hasSmallFactors   = !hasNoSmallFactors;
 	if(hasSmallFactors){
-		return 0;
+		return GA_IS_COMPOSITE;
 	}
 
 	/**
-	 * Otherwise proceed to the Miller-Rabin test.
+	 * We implement the Baillie-Pomerance-Selfridge-Wagstaff primality checker.
+	 *   1) A Fermat base-2 strong probable prime that is also
+	 *   2) A Lucas strong probable prime is
+	 *   3) Prime.
+	 * The BPSW test has no known failure cases and is proven to have no failures
+	 * for all numbers under 2^64. It is expected to have failures (composites
+	 * classified as "probably prime") but they are expected to be enormous.
 	 *
-	 * The Miller-Rabin test uses integer "witnesses" in an attempt at
-	 * proving the number composite. Should it fail to prove an integer
-	 * composite, it reports the number as "probably prime". However, if
-	 * the witnesses are chosen carefully, the Miller-Rabin test can be made
-	 * deterministic below a chosen threshold. In our case, we use the primes
-	 * 2 to 37 in order to ensure the correctness of the identifications for
-	 * integers under 2^64.
+	 * We begin with the Fermat base-2 strong primality test
+	 * (Miller-Rabin test with one witness only, a=2).
 	 */
 
-	r = gaICtz(n-1);
-	d = (n-1)>>r;
-
-	/* For each witness... */
-	for(i=0;i<NUMWITNESSES;i++){
-		uint64_t a = WITNESSES[i];
-
-		/* Modular exponentiation of witness by d, modulo the prime. */
-		uint64_t x = gaIPowMod(a,d,n);
-
-		/**
-		 * If result is 1 or n-1, test inconclusive (can't prove
-		 * compositeness).
-		 */
-
-		if(x==1 || x==n-1){goto continueWitnessLoop;}
-
-		/**
-		 * Otherwise, modulo-square x r-1 times. If result is ever 1, it's
-		 * composite. If result is ever n-1, it's inconclusive. If after r-1
-		 * iterations neither 1 nor n-1 came up, it's composite.
-		 */
-
-		for(j=0;j<r-1;j++){
-			x = gaIPowMod(x,2,n);
-
-			if(x==1){
-				/* Composite! */
-				return 0;
-			}else if(x == n-1){
-				/* Inconclusive (can't prove compositeness) */
-				goto continueWitnessLoop;
-			}
-		}
-
-		/* Composite! */
-		return 0;
-
-		continueWitnessLoop:;
-	}
+	return gaIIsPrimeStrongFermat(n,          2) &&
 
 	/**
-	 * Having failed to prove this is a composite, and given our choice of
-	 * witnesses, we know we've identified a prime.
+	 * Assuming this is one of the base-2 Fermat strong probable primes, we run
+	 * the Lucas primality test with Selfridge's Method A for selecting D.
 	 */
 
-	return 1;
+	       gaIIsPrimeStrongLucas (n            );
 }
 
 int      gaIFactorize (uint64_t n, uint64_t maxN, uint64_t k, ga_factor_list* fl){
@@ -568,22 +867,22 @@ static int      gaIFactorize2Smooth(uint64_t n, ga_factor_list* fl){
 static int      gaIFactorize3Smooth(uint64_t n, ga_factor_list* fl){
 	uint64_t nBest=-1, i3Best=0, i3, p3, nCurr;
 	int nlz = gaIClz(n), isBest2to64 = 1;
-	
+
 	/**
 	 * Iterate over all powers of 3, scaling them by the least power-of-2 such
 	 * that the result is greater than or equal to n. Report the smallest nBest
 	 * so obtained.
 	 */
-	
+
 	for(i3=0, p3=1;i3<=40;i3++, p3*=3){
 		nCurr = p3;
-		
+
 		/**
 		 * If the current power of 3 is >= n, then this must be the last
 		 * iteration, but perhaps a pure power of 3 is the best choice, so
 		 * check for this.
 		 */
-		
+
 		if(nCurr >= n){
 			if(isBest2to64 || nBest >= nCurr){
 				isBest2to64 = 0;
@@ -592,14 +891,14 @@ static int      gaIFactorize3Smooth(uint64_t n, ga_factor_list* fl){
 			}
 			break;
 		}
-		
+
 		/**
 		 * Otherwise we have a pure power of 3, p3, less than n, and must
 		 * derive the least power of 2 such that p3 multiplied by that power of
 		 * 2 is greater than or equal to n. We then compute the product of
 		 * both.
 		 */
-		
+
 		nCurr <<= gaIClz(nCurr) - nlz;
 		if(nCurr<n){
 			/**
@@ -607,7 +906,7 @@ static int      gaIFactorize3Smooth(uint64_t n, ga_factor_list* fl){
 			 * 2 from n. We may have to boost nCurr by another factor of 2, if
 			 * this is still possible without overflow.
 			 */
-			
+
 			nCurr<<=1;
 			if(nCurr<n){
 				/**
@@ -615,34 +914,34 @@ static int      gaIFactorize3Smooth(uint64_t n, ga_factor_list* fl){
 				 * that (before overflow) it was the case that 2^63 <= nCurr < n,
 				 * and thus 2**64 is a superior factorization to this one. Skip.
 				 */
-				
+
 				continue;
 			}
 		}
-		
+
 		/**
 		 * By here we know that nCurr is >= n. But is it the best factorization
 		 * so far?
 		 */
-		
+
 		if(isBest2to64 || nBest >= nCurr){
 			isBest2to64 = 0;
 			nBest       = nCurr;
 			i3Best      = i3;
-			
+
 			if(nCurr == n){
 				break;
 			}
 		}
 	}
-	
-	
+
+
 	/**
 	 * Return the smallest n found above.
-	 * 
+	 *
 	 * nBest and i3Best must be set.
 	 */
-	
+
 	gaIFLInit(fl);
 	if(isBest2to64){
 		gaIFLAddFactors(fl, 2, 64);
@@ -656,22 +955,22 @@ static int      gaIFactorize3Smooth(uint64_t n, ga_factor_list* fl){
 static int      gaIFactorize5Smooth(uint64_t n, ga_factor_list* fl){
 	uint64_t nBest=-1, i3Best=0, i3, p3, i5Best=0, i5, p5, nCurr;
 	int nlz = gaIClz(n), isBest2to64 = 1;
-	
+
 	/**
 	 * Iterate over all products of powers of 5 and 3, scaling them by the
 	 * least power-of-2 such that the result is greater than or equal to n.
 	 * Report the smallest nBest so obtained.
 	 */
-	
+
 	for(i5=0, p5=1;i5<=27;i5++, p5*=5){
 		nCurr = p5;
-		
+
 		/**
 		 * If the current power of 5 is >= n, then this must be the last
 		 * iteration, but perhaps a pure power of 5 is the best choice, so
 		 * check for this.
 		 */
-		
+
 		if(nCurr >= n){
 			if(isBest2to64 || nBest >= nCurr){
 				isBest2to64 = 0;
@@ -681,16 +980,16 @@ static int      gaIFactorize5Smooth(uint64_t n, ga_factor_list* fl){
 			}
 			break;
 		}
-		
+
 		for(i3=0, p3=1;i3<=40;i3++, p3*=3){
 			nCurr = p3*p5;
-			
+
 			/**
 			 * If the current product of powers of 3 and 5 is >= n, then this
 			 * must be the last iteration, but perhaps a pure power of 3 is the
 			 * best choice, so check for this.
 			 */
-			
+
 			if(nCurr >= n){
 				if(isBest2to64 || nBest >= nCurr){
 					isBest2to64 = 0;
@@ -700,14 +999,14 @@ static int      gaIFactorize5Smooth(uint64_t n, ga_factor_list* fl){
 				}
 				break;
 			}
-			
+
 			/**
 			 * Otherwise we have a number nCurr, composed purely of factors 3
 			 * and 5, that is less than n. We must derive the least power of 2
 			 * such that nCurr multiplied by that power of 2 is greater than or
 			 * equal to n. We then compute the product of both.
 			 */
-			
+
 			nCurr <<= gaIClz(nCurr) - nlz;
 			if(nCurr<n){
 				/**
@@ -715,7 +1014,7 @@ static int      gaIFactorize5Smooth(uint64_t n, ga_factor_list* fl){
 				 * 2 from n. We may have to boost nCurr by another factor of 2, if
 				 * this is still possible without overflow.
 				 */
-				
+
 				nCurr<<=1;
 				if(nCurr<n){
 					/**
@@ -723,37 +1022,37 @@ static int      gaIFactorize5Smooth(uint64_t n, ga_factor_list* fl){
 					 * that (before overflow) it was the case that 2^63 <= nCurr < n,
 					 * and thus 2**64 is a superior factorization to this one. Skip.
 					 */
-					
+
 					continue;
 				}
 			}
-			
+
 			/**
 			 * By here we know that nCurr is >= n. But is it the best factorization
 			 * so far?
 			 */
-			
+
 			if(isBest2to64 || nBest >= nCurr){
 				isBest2to64 = 0;
 				nBest       = nCurr;
 				i3Best      = i3;
 				i5Best      = i5;
-				
+
 				if(nCurr == n){
 					goto exit;
 				}
 			}
 		}
 	}
-	
-	
+
+
 	/**
 	 * Return the smallest n found above.
-	 * 
+	 *
 	 * nBest and i3Best must be set.
 	 */
-	
-	exit:
+
+    exit:
 	gaIFLInit(fl);
 	if(isBest2to64){
 		gaIFLAddFactors(fl, 2, 64);
@@ -875,14 +1174,14 @@ uint64_t gaIFLGetProduct(const ga_factor_list* fl){
 int      gaIFLIsOverflowed(const ga_factor_list* fl){
 	uint64_t p = 1, MAX=-1;
 	int i, j;
-	
+
 	if(gaIFLGetFactorPower(fl, 0) >=  1){
 		return 0;
 	}
 	if(gaIFLGetFactorPower(fl, 2) >= 64){
 		return 1;
 	}
-	
+
 	for(i=0;i<fl->d;i++){
 		for(j=0;j<fl->p[i];j++){
 			if(MAX/p < fl->f[i]){
@@ -891,7 +1190,7 @@ int      gaIFLIsOverflowed(const ga_factor_list* fl){
 			p *= fl->f[i];
 		}
 	}
-	
+
 	return 0;
 }
 
@@ -954,22 +1253,60 @@ static uint64_t gaIFLGetSmallestFactorv(int n, const ga_factor_list* fl, int* id
 	return hasFactors ? f : 1;
 }
 
+int      gaIFLsprintf(char* str, const ga_factor_list* fl){
+	int    i, j;
+	int    total = 0;
+	char*  ptr   = str;
+
+	/* Loop over all factors and spit them out. */
+	for(i=0;i<fl->d;i++){
+		for(j=0;j<fl->p[i];j++){
+			total += sprintf(ptr, "%llu*", (unsigned long long)fl->f[i]);
+			if(ptr){
+				ptr   += strlen(ptr);
+			}
+		}
+	}
+
+	/* If no factors were printed, print 1. */
+	if(total == 0){
+		total += sprintf(ptr, "1*");
+		if(ptr){
+			ptr   += strlen(ptr);
+		}
+	}
+
+	/* Terminate buffer ('*' -> '\0') and deduct one character. */
+	total--;
+	if(str){
+		str[total]  = '\0';
+	}
+
+	return total;
+}
+
 void gaIFLappend(strb *sb, const ga_factor_list* fl){
-  int i, j;
-  /* Loop over all factors and spit them out. */
-  for (i = 0; i < fl->d; i++) {
-    for (j = 0; j < fl->p[i]; j++) {
-      strb_appendf(sb, "%llu*", (unsigned long long)fl->f[i]);
-    }
-  }
+	int  i, j;
+	int  noFactorsPrinted = 1;
 
-  /* If no factors were printed, print 1. */
-  if (i == 0 && j == 0) {
-    strb_appendf(sb, "1*");
-  }
+	/* Loop over all factors and spit them out. */
+	for(i=0;i<fl->d;i++){
+		for(j=0;j<fl->p[i];j++){
+			noFactorsPrinted = 0;
+			strb_appendf(sb, "%llu*", (unsigned long long)fl->f[i]);
+		}
+	}
 
-  /* Deduct final '*'. */
-  sb->l -= 1;
+	/**
+	 * If no factors were printed, print 1.
+	 * Otherwise, delete final '*'.
+	 */
+
+	if(noFactorsPrinted){
+		strb_appendf(sb, "1");
+	}else{
+		sb->s[--sb->l] = '\0';
+	}
 }
 
 void     gaIFLSchedule(const int       n,

--- a/src/util/integerfactoring.c
+++ b/src/util/integerfactoring.c
@@ -715,8 +715,8 @@ int      gaIFactorize (uint64_t n, uint64_t maxN, uint64_t k, ga_factor_list* fl
 	 * Magic-value arguments interpreted and canonicalized.
 	 */
 
-	exactFactoring  = (maxN ==  0);
-	infiniteSlack   = (maxN == -1);
+	exactFactoring  = (maxN == (uint64_t) 0);
+	infiniteSlack   = (maxN == (uint64_t)-1);
 	noKSmoothness   = (k    == 0) || (k >= n);
 	finiteSlack     = !infiniteSlack;
 	kSmoothness     = !noKSmoothness;

--- a/src/util/integerfactoring.h
+++ b/src/util/integerfactoring.h
@@ -91,16 +91,18 @@ int      gaIIsPrime(uint64_t n);
  * The advantage of offering some slack to the factorizer is that in return,
  * the factorizer may succeed in outputting a factorization with smaller
  * factors. The maxN slack parameter must be 0 or be greater than or equal to
- * n, but it is useless to set it beyond twice the value of n.
+ * n, but it is completely useless to set it beyond 2n.
  *
- * When maxN is equal to -1 (2^64 - 1), or is greater than or equal to 2n,
- * there is a guarantee that there exists a power of two that lies between n
- * and 2n. Since this factorization involves only powers of the smallest prime
- * (2), it is a valid factorization under any valid k-smoothness constraint,
- * and so will be returned.
+ * When maxN is equal to -1 (2^64 - 1), or is greater than or equal to 2n, no
+ * upper limit is placed on the output factor list's product, but this
+ * implementation guarantees its product will not exceed 2n. This is because
+ * there always exists a power of two that lies between n and 2n, and since
+ * this factorization involves only powers of the smallest prime (2), it is a
+ * valid factorization under any valid k-smoothness constraint, and so may be
+ * returned.
  *
- * When maxN is equal to 0 or n (no increase in value allowed), this implies
- * that an exact factoring is requested.
+ * When maxN is equal to 0 (no increase in value allowed), an exact factoring
+ * is requested.
  *
  * The factorization can also be constrained by a (k)-smoothness constraint.
  * A k-smooth number n has no prime factors greater than k. If the factorizer
@@ -147,7 +149,7 @@ void     gaIFLInit(ga_factor_list* fl);
  *         and non-zero otherwise.
  */
 
-int      gaIFLFull(ga_factor_list* fl);
+int      gaIFLFull(const ga_factor_list* fl);
 
 /**
  * @brief Add a factor f with power p to the factor list.
@@ -170,13 +172,22 @@ int      gaIFLAddFactors(ga_factor_list* fl, uint64_t f, int p);
  *         factorization. If it does not occur, return 0.
  */
 
-int      gaIFLGetFactorPower(ga_factor_list* fl, uint64_t f);
+int      gaIFLGetFactorPower(const ga_factor_list* fl, uint64_t f);
 
 /**
  * @brief Compute the product of the factors stored in the factors list.
+ * 
+ * NB: This function may return an overflowed result. To detect if it will,
+ *     please call gaIFLIsOverflowed(fl).
  */
 
 uint64_t gaIFLGetProduct(const ga_factor_list* fl);
+
+/**
+ * @brief Check whether the factor list produces a number >= 2^64.
+ */
+
+int      gaIFLIsOverflowed(const ga_factor_list* fl);
 
 /**
  * @brief Get the greatest factor in the factors list.

--- a/src/util/integerfactoring.h
+++ b/src/util/integerfactoring.h
@@ -202,6 +202,20 @@ uint64_t gaIFLGetGreatestFactor(const ga_factor_list* fl);
 uint64_t gaIFLGetSmallestFactor(const ga_factor_list* fl);
 
 /**
+ * @brief Print out the factor list in a human-readable form, sprintf()-style.
+ * 
+ * @param [out] str   A string into which to print out the factor list. If the
+ *                    factor list is a result of gaIFactorize(), then the
+ *                    maximum length of buffer required is 128 bytes.
+ *                    If str is NULL, nothing is printed.
+ * @param [in]  fl    The factor list to be printed.
+ * @return            The number of characters that would have been printed
+ *                    out, assuming an unbounded, non-NULL buffer.
+ */
+
+int gaIFLsprintf(char* str, const ga_factor_list* fl);
+
+/**
  * @brief Print out the factor list in a human-readable form.
  *
  * @param [out] sb   A string into which to print out the factor list. If the
@@ -210,7 +224,7 @@ uint64_t gaIFLGetSmallestFactor(const ga_factor_list* fl);
  * @param [in]  fl   The factor list to be printed.
  */
 
-void gaIFLsnprintf(strb *sb, const ga_factor_list* fl);
+void gaIFLappend(strb *sb, const ga_factor_list* fl);
 
 /**
  * @brief Schedule block size, grid size and what's left over that fits in

--- a/src/util/integerfactoring.h
+++ b/src/util/integerfactoring.h
@@ -244,16 +244,27 @@ void gaIFLappend(strb *sb, const ga_factor_list* fl);
  * @param [in,out] factBS   The block size for dimensions 0..n-1, as a factor list.
  * @param [in,out] factGS   The grid  size for dimensions 0..n-1, as a factor list.
  * @param [in,out] factCS   The chunk size for dimensions 0..n-1, as a factor list.
+ * @param [in,out] bs       The block size for dimensions 0..n-1, as an integer.
+ * @param [in,out] gs       The grid  size for dimensions 0..n-1, as an integer.
+ * @param [in,out] cs       The chunk size for dimensions 0..n-1, as an integer.
  */
 
-void  gaIFLSchedule(const int       n,
-                    const uint64_t  maxBtot,
-                    const uint64_t* maxBind,
-                    const uint64_t  maxGtot,
-                    const uint64_t* maxGind,
-                    ga_factor_list* factBS,
-                    ga_factor_list* factGS,
-                    ga_factor_list* factCS);
+void     gaIFLSchedule(const int       n,
+                       const uint64_t  maxBtot,
+                       const uint64_t* maxBind,
+                       const uint64_t  maxGtot,
+                       const uint64_t* maxGind,
+                       ga_factor_list* factBS,
+                       ga_factor_list* factGS,
+                       ga_factor_list* factCS);
+void     gaISchedule  (const int       n,
+                       const uint64_t  maxBtot,
+                       const uint64_t* maxBind,
+                       const uint64_t  maxGtot,
+                       const uint64_t* maxGind,
+                       uint64_t*       bs,
+                       uint64_t*       gs,
+                       uint64_t*       cs);
 
 
 /* End C++ Extern "C" Guard */

--- a/tests/check_reduction.c
+++ b/tests/check_reduction.c
@@ -69,84 +69,84 @@ static       double   pcgRand01(void){
 
 START_TEST(test_reduction){
 	pcgSeed(1);
-	
+
 	/**
 	 * We test here a reduction of some random 3D tensor on the first and
 	 * third dimensions.
 	 */
-	
+
 	size_t i,j,k;
 	size_t dims[3]  = {32,50,79};
 	size_t prodDims = dims[0]*dims[1]*dims[2];
 	const unsigned reduxList[] = {0,2};
-	
+
 	float*  pSrc    = calloc(1, sizeof(*pSrc)    * dims[0]*dims[1]*dims[2]);
 	float*  pMax    = calloc(1, sizeof(*pMax)    *         dims[1]        );
 	size_t* pArgmax = calloc(1, sizeof(*pArgmax) *         dims[1]        );
-	
+
 	ck_assert_ptr_ne(pSrc,    NULL);
 	ck_assert_ptr_ne(pMax,    NULL);
 	ck_assert_ptr_ne(pArgmax, NULL);
-	
-	
+
+
 	/**
 	 * Initialize source data.
 	 */
-	
+
 	for(i=0;i<prodDims;i++){
 		pSrc[i] = pcgRand01();
 	}
-	
-	
+
+
 	/**
 	 * Run the kernel.
 	 */
-	
+
 	GpuArray gaSrc;
 	GpuArray gaMax;
 	GpuArray gaArgmax;
-	
+
 	ga_assert_ok(GpuArray_empty(&gaSrc,    ctx, GA_FLOAT, 3, &dims[0], GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaMax,    ctx, GA_FLOAT, 1, &dims[1], GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaArgmax, ctx, GA_SIZE,  1, &dims[1], GA_C_ORDER));
-	
+
 	ga_assert_ok(GpuArray_write(&gaSrc,    pSrc, sizeof(*pSrc)*prodDims));
 	ga_assert_ok(GpuArray_memset(&gaMax,    -1));  /* 0xFFFFFFFF is a qNaN. */
 	ga_assert_ok(GpuArray_memset(&gaArgmax, -1));
-	
+
 	ga_assert_ok(GpuArray_maxandargmax(&gaMax, &gaArgmax, &gaSrc, 2, reduxList));
-	
+
 	ga_assert_ok(GpuArray_read(pMax,    sizeof(*pMax)   *dims[1], &gaMax));
 	ga_assert_ok(GpuArray_read(pArgmax, sizeof(*pArgmax)*dims[1], &gaArgmax));
-	
-	
+
+
 	/**
 	 * Check that the destination tensors are correct.
 	 */
-	
+
 	for(j=0;j<dims[1];j++){
 		size_t gtArgmax = 0;
 		float  gtMax    = pSrc[(0*dims[1] + j)*dims[2] + 0];
-		
+
 		for(i=0;i<dims[0];i++){
 			for(k=0;k<dims[2];k++){
 				float v = pSrc[(i*dims[1] + j)*dims[2] + k];
-				
+
 				if(v > gtMax){
 					gtMax    = v;
 					gtArgmax = i*dims[2] + k;
 				}
 			}
 		}
-		
+
 		ck_assert_msg(gtMax    == pMax[j],    "Max value mismatch!");
 		ck_assert_msg(gtArgmax == pArgmax[j], "Argmax value mismatch!");
 	}
-	
+
 	/**
 	 * Deallocate.
 	 */
-	
+
 	free(pSrc);
 	free(pMax);
 	free(pArgmax);
@@ -157,88 +157,88 @@ START_TEST(test_reduction){
 
 START_TEST(test_idxtranspose){
 	pcgSeed(1);
-	
+
 	/**
 	 * We test here the same reduction as test_reduction, except with a
 	 * reversed reduxList {2,0} instead of {0,2}. That should lead to a
 	 * transposition of the argmax "coordinates" and thus a change in its
 	 * "flattened" output version.
 	 */
-	
+
 	size_t i,j,k;
 	size_t dims[3]     = {32,50,79};
 	size_t prodDims    = dims[0]*dims[1]*dims[2];
 	size_t rdxDims[1]  = {50};
 	size_t rdxProdDims = rdxDims[0];
 	const unsigned reduxList[] = {2,0};
-	
+
 	float*  pSrc    = calloc(1, sizeof(*pSrc)    * prodDims);
 	float*  pMax    = calloc(1, sizeof(*pMax)    * rdxProdDims);
 	size_t* pArgmax = calloc(1, sizeof(*pArgmax) * rdxProdDims);
-	
+
 	ck_assert_ptr_ne(pSrc,    NULL);
 	ck_assert_ptr_ne(pMax,    NULL);
 	ck_assert_ptr_ne(pArgmax, NULL);
-	
-	
+
+
 	/**
 	 * Initialize source data.
 	 */
-	
+
 	for(i=0;i<prodDims;i++){
 		pSrc[i] = pcgRand01();
 	}
-	
-	
+
+
 	/**
 	 * Run the kernel.
 	 */
-	
+
 	GpuArray gaSrc;
 	GpuArray gaMax;
 	GpuArray gaArgmax;
-	
+
 	ga_assert_ok(GpuArray_empty(&gaSrc,    ctx, GA_FLOAT, 3, dims,    GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaMax,    ctx, GA_FLOAT, 1, rdxDims, GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaArgmax, ctx, GA_SIZE,  1, rdxDims, GA_C_ORDER));
-	
+
 	ga_assert_ok(GpuArray_write(&gaSrc,    pSrc, sizeof(*pSrc)*prodDims));
 	ga_assert_ok(GpuArray_memset(&gaMax,    -1));  /* 0xFFFFFFFF is a qNaN. */
 	ga_assert_ok(GpuArray_memset(&gaArgmax, -1));
-	
+
 	ga_assert_ok(GpuArray_maxandargmax(&gaMax, &gaArgmax, &gaSrc, 2, reduxList));
-	
+
 	ga_assert_ok(GpuArray_read(pMax,    sizeof(*pMax)   *rdxProdDims, &gaMax));
 	ga_assert_ok(GpuArray_read(pArgmax, sizeof(*pArgmax)*rdxProdDims, &gaArgmax));
-	
-	
+
+
 	/**
 	 * Check that the destination tensors are correct.
 	 */
-	
+
 	for(j=0;j<dims[1];j++){
 		size_t gtArgmax = 0;
 		float  gtMax    = pSrc[(0*dims[1] + j)*dims[2] + 0];
-		
+
 		for(k=0;k<dims[2];k++){
 			for(i=0;i<dims[0];i++){
 				float v = pSrc[(i*dims[1] + j)*dims[2] + k];
-				
+
 				if(v > gtMax){
 					gtMax    = v;
 					gtArgmax = k*dims[0] + i;
 				}
 			}
 		}
-		
+
 		ck_assert_msg(gtMax    == pMax[j],    "Max value mismatch!");
 		ck_assert_msg(gtArgmax == pArgmax[j], "Argmax value mismatch!");
 	}
-	
+
 	/**
 	 * Deallocate.
 	 */
-	
+
 	free(pSrc);
 	free(pMax);
 	free(pArgmax);
@@ -249,75 +249,75 @@ START_TEST(test_idxtranspose){
 
 START_TEST(test_veryhighrank){
 	pcgSeed(1);
-	
+
 	/**
 	 * Here we test a reduction of a random 8D tensor on four dimensions.
 	 */
-	
+
 	size_t i,j,k,l,m,n,o,p;
 	size_t dims   [8]  = {1171,373,2,1,2,1,2,1};
 	size_t prodDims    = dims[0]*dims[1]*dims[2]*dims[3]*dims[4]*dims[5]*dims[6]*dims[7];
 	size_t rdxDims[4]  = {1171,373,1,2};
 	size_t rdxProdDims = rdxDims[0]*rdxDims[1]*rdxDims[2]*rdxDims[3];
 	const unsigned reduxList[] = {2,4,7,5};
-	
+
 	float*  pSrc    = calloc(1, sizeof(*pSrc)    * prodDims);
 	float*  pMax    = calloc(1, sizeof(*pMax)    * rdxProdDims);
 	size_t* pArgmax = calloc(1, sizeof(*pArgmax) * rdxProdDims);
-	
+
 	ck_assert_ptr_ne(pSrc,    NULL);
 	ck_assert_ptr_ne(pMax,    NULL);
 	ck_assert_ptr_ne(pArgmax, NULL);
-	
-	
+
+
 	/**
 	 * Initialize source data.
 	 */
-	
+
 	for(i=0;i<prodDims;i++){
 		pSrc[i] = pcgRand01();
 	}
-	
-	
+
+
 	/**
 	 * Run the kernel.
 	 */
-	
+
 	GpuArray gaSrc;
 	GpuArray gaMax;
 	GpuArray gaArgmax;
-	
+
 	ga_assert_ok(GpuArray_empty(&gaSrc,    ctx, GA_FLOAT, 8, dims,    GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaMax,    ctx, GA_FLOAT, 4, rdxDims, GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaArgmax, ctx, GA_SIZE,  4, rdxDims, GA_C_ORDER));
-	
+
 	ga_assert_ok(GpuArray_write(&gaSrc,    pSrc, sizeof(*pSrc)*prodDims));
 	ga_assert_ok(GpuArray_memset(&gaMax,    -1));  /* 0xFFFFFFFF is a qNaN. */
 	ga_assert_ok(GpuArray_memset(&gaArgmax, -1));
-	
+
 	ga_assert_ok(GpuArray_maxandargmax(&gaMax, &gaArgmax, &gaSrc, 4, reduxList));
-	
+
 	ga_assert_ok(GpuArray_read(pMax,    sizeof(*pMax)   *rdxProdDims, &gaMax));
 	ga_assert_ok(GpuArray_read(pArgmax, sizeof(*pArgmax)*rdxProdDims, &gaArgmax));
-	
-	
+
+
 	/**
 	 * Check that the destination tensors are correct.
 	 */
-	
+
 	for(i=0;i<dims[0];i++){
 		for(j=0;j<dims[1];j++){
 			for(l=0;l<dims[3];l++){
 				for(o=0;o<dims[6];o++){
 					size_t gtArgmax = 0;
 					float  gtMax    = pSrc[(((((((i)*dims[1] + j)*dims[2] + 0)*dims[3] + l)*dims[4] + 0)*dims[5] + 0)*dims[6] + o)*dims[7] + 0];
-					
+
 					for(k=0;k<dims[2];k++){
 						for(m=0;m<dims[4];m++){
 							for(p=0;p<dims[7];p++){
 								for(n=0;n<dims[5];n++){
 									float v = pSrc[(((((((i)*dims[1] + j)*dims[2] + k)*dims[3] + l)*dims[4] + m)*dims[5] + n)*dims[6] + o)*dims[7] + p];
-									
+
 									if(v > gtMax){
 										gtMax    = v;
 										gtArgmax = (((k)*dims[4] + m)*dims[7] + p)*dims[5] + n;
@@ -326,7 +326,7 @@ START_TEST(test_veryhighrank){
 							}
 						}
 					}
-					
+
 					size_t dstIdx = (((i)*dims[1] + j)*dims[3] + l)*dims[6] + o;
 					ck_assert_msg(gtMax    == pMax[dstIdx],    "Max value mismatch!");
 					ck_assert_msg(gtArgmax == pArgmax[dstIdx], "Argmax value mismatch!");
@@ -334,12 +334,12 @@ START_TEST(test_veryhighrank){
 			}
 		}
 	}
-	
-	
+
+
 	/**
 	 * Deallocate.
 	 */
-	
+
 	free(pSrc);
 	free(pMax);
 	free(pArgmax);
@@ -353,11 +353,11 @@ Suite *get_suite(void) {
 	TCase *tc = tcase_create("basic");
 	tcase_add_checked_fixture(tc, setup, teardown);
 	tcase_set_timeout(tc, 15.0);
-	
+
 	tcase_add_test(tc, test_reduction);
 	tcase_add_test(tc, test_idxtranspose);
 	tcase_add_test(tc, test_veryhighrank);
-	
+
 	suite_add_tcase(s, tc);
 	return s;
 }

--- a/tests/check_util_integerfactoring.c
+++ b/tests/check_util_integerfactoring.c
@@ -57,6 +57,7 @@ START_TEST(test_primalitychecker){
 	ck_assert(!gaIIsPrime(                1905ULL));
 	ck_assert(!gaIIsPrime(                2047ULL));
 	ck_assert(!gaIIsPrime(                2465ULL));
+	ck_assert(!gaIIsPrime(              486737ULL));
 	/* Strong Lucas pseudoprimes */
 	ck_assert(!gaIIsPrime(                5459ULL));
 	ck_assert(!gaIIsPrime(                5459ULL));

--- a/tests/check_util_integerfactoring.c
+++ b/tests/check_util_integerfactoring.c
@@ -9,25 +9,117 @@
 
 
 /**
+ * Primality Checker
+ */
+
+START_TEST(test_primalitychecker){
+	/* Tiny numbers */
+	ck_assert(!gaIIsPrime(                   0ULL));
+	ck_assert(!gaIIsPrime(                   1ULL));
+	ck_assert( gaIIsPrime(                   2ULL));
+	ck_assert( gaIIsPrime(                   3ULL));
+	ck_assert(!gaIIsPrime(                   4ULL));
+	ck_assert( gaIIsPrime(                   5ULL));
+	ck_assert(!gaIIsPrime(                   6ULL));
+	ck_assert( gaIIsPrime(                   7ULL));
+	ck_assert(!gaIIsPrime(                   8ULL));
+	ck_assert(!gaIIsPrime(                   9ULL));
+	ck_assert(!gaIIsPrime(                  10ULL));
+	ck_assert( gaIIsPrime(                  11ULL));
+	ck_assert(!gaIIsPrime(                  12ULL));
+	ck_assert( gaIIsPrime(                  13ULL));
+	ck_assert(!gaIIsPrime(                  14ULL));
+	ck_assert(!gaIIsPrime(                  15ULL));
+	ck_assert(!gaIIsPrime(                  16ULL));
+	ck_assert( gaIIsPrime(                  17ULL));
+	ck_assert(!gaIIsPrime(                  18ULL));
+	ck_assert( gaIIsPrime(                  19ULL));
+	ck_assert(!gaIIsPrime(                  20ULL));
+	/* Small primes */
+	ck_assert( gaIIsPrime(                4987ULL));
+	ck_assert( gaIIsPrime(                4993ULL));
+	ck_assert( gaIIsPrime(                4999ULL));
+	/* Squares of primes */
+	ck_assert(!gaIIsPrime(            24870169ULL));
+	ck_assert(!gaIIsPrime(            24930049ULL));
+	ck_assert(!gaIIsPrime(            24990001ULL));
+	/* Catalan pseudoprimes */
+	ck_assert(!gaIIsPrime(                5907ULL));
+	ck_assert(!gaIIsPrime(             1194649ULL));
+	ck_assert(!gaIIsPrime(            12327121ULL));
+	/* Fermat base-2 pseudoprimes */
+	ck_assert(!gaIIsPrime(                 341ULL));
+	ck_assert(!gaIIsPrime(                 561ULL));
+	ck_assert(!gaIIsPrime(                 645ULL));
+	ck_assert(!gaIIsPrime(                1105ULL));
+	ck_assert(!gaIIsPrime(                1387ULL));
+	ck_assert(!gaIIsPrime(                1729ULL));
+	ck_assert(!gaIIsPrime(                1905ULL));
+	ck_assert(!gaIIsPrime(                2047ULL));
+	ck_assert(!gaIIsPrime(                2465ULL));
+	/* Strong Lucas pseudoprimes */
+	ck_assert(!gaIIsPrime(                5459ULL));
+	ck_assert(!gaIIsPrime(                5459ULL));
+	ck_assert(!gaIIsPrime(                5459ULL));
+	ck_assert(!gaIIsPrime(                5777ULL));
+	ck_assert(!gaIIsPrime(               10877ULL));
+	ck_assert(!gaIIsPrime(               16109ULL));
+	ck_assert(!gaIIsPrime(               18971ULL));
+	ck_assert(!gaIIsPrime(               22499ULL));
+	ck_assert(!gaIIsPrime(               24569ULL));
+	ck_assert(!gaIIsPrime(               25199ULL));
+	ck_assert(!gaIIsPrime(               40309ULL));
+	ck_assert(!gaIIsPrime(               58519ULL));
+	ck_assert(!gaIIsPrime(               75077ULL));
+	ck_assert(!gaIIsPrime(               97439ULL));
+	ck_assert(!gaIIsPrime(              100127ULL));
+	ck_assert(!gaIIsPrime(              113573ULL));
+	ck_assert(!gaIIsPrime(              115639ULL));
+	ck_assert(!gaIIsPrime(              130139ULL));
+	/* Medium, prime. */
+	ck_assert( gaIIsPrime(          2100000011ULL));
+	ck_assert( gaIIsPrime(          2100000017ULL));
+	/* Large, non-smooth, composite */
+	ck_assert(!gaIIsPrime( 2196095973992233039ULL));
+	/* Largest prime < 2**64: */
+	ck_assert( gaIIsPrime(18446744073709551557ULL));
+	/* Largest integers */
+	ck_assert(!gaIIsPrime(18446744073709551613ULL));
+	ck_assert(!gaIIsPrime(18446744073709551614ULL));
+	ck_assert(!gaIIsPrime(18446744073709551615ULL));
+}END_TEST
+
+/**
  * Integer Factorization test
  */
 
 START_TEST(test_integerfactorization){
 	ga_factor_list fl;
+	uint64_t       n;
 	
 	/**
 	 * Attempt exact factorization for 2^64-1, no k-smoothness constraint.
 	 * Expected PASS with 3*5*17*257*641*65537*6700417
 	 */
 	
-	ck_assert_int_ne(gaIFactorize(18446744073709551615ULL,                            0,     0, &fl), 0);
+	n = 18446744073709551615ULL;
+	ck_assert_int_ne (gaIFactorize(n,         0,     0, &fl), 0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    3ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                   17ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                  257ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                  641ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                65537ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,              6700417ULL),  1);
+	ck_assert_uint_eq(gaIFLGetProduct(&fl), n);
 	
 	/**
 	 * Attempt exact factorization for 2^64-1, 4096-smooth constraint.
 	 * Expected FAIL, because 2^64-1 possesses prime factors in excess of 4096.
 	 */
 	
-	ck_assert_int_eq(gaIFactorize(18446744073709551615ULL,                            0,  4096, &fl), 0);
+	n = 18446744073709551615ULL;
+	ck_assert_int_eq (gaIFactorize(n,         0,  4096, &fl), 0);
 	
 	/**
 	 * Attempt approximate factorization for 2^64-1, no k-smoothness constraint.
@@ -35,7 +127,11 @@ START_TEST(test_integerfactorization){
 	 * Expected PASS, since 2^64-1 rounds up to 2^64 and 2^64 trivially factorizes.
 	 */
 	
-	ck_assert_int_ne(gaIFactorize(18446744073709551615ULL,                           -1,     0, &fl), 0);
+	n = 18446744073709551615ULL;
+	ck_assert_int_ne (gaIFactorize(n,        -1,     0, &fl), 0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 64);
+	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 2);
+	ck_assert_int_ne (gaIFLIsOverflowed(&fl), 0);
 	
 	/**
 	 * Attempt exact factorization for 2196095973992233039, no k-smoothness constraint.
@@ -44,18 +140,101 @@ START_TEST(test_integerfactorization){
 	 * Expected PASS *very quickly*, since it factorizes as 1299817*1299821*1299827
 	 */
 	
-	ck_assert_int_ne(gaIFactorize( 2196095973992233039ULL,                            0,     0, &fl), 0);
+	n =  2196095973992233039ULL;
+	ck_assert_int_ne (gaIFactorize(n,         0,     0, &fl), 0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,              1299817ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,              1299821ULL),  1);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,              1299827ULL),  1);
+	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 1299827);
+	ck_assert_uint_eq(gaIFLGetProduct(&fl), n);
 	
 	/**
-	 * Attempt approximate factorization for 2196095973992233039, 64-smooth constraint.
+	 * Attempt approximate factorization for 2196095973992233039, 16-smooth constraint.
 	 * 2196095973992233039 is a large, highly non-smooth number, with three enormous
 	 * factors. It is not 64-smooth, so code paths that attempt approximate
-	 * factorization within the growth limits (1%) are exercised.
+	 * factorization within the growth limits (.005%) are exercised.
 	 * 
 	 * Expected PASS *relatively quickly*.
 	 */
 	
-	ck_assert_int_ne(gaIFactorize( 2196095973992233039ULL,  2196095973992233039ULL*1.01,    64, &fl), 0);
+	n =  2196095973992233039ULL;
+	ck_assert_int_ne (gaIFactorize(n, n*1.00005,    16, &fl), 0);
+	ck_assert_uint_ge(gaIFLGetProduct(&fl), n);
+	ck_assert_uint_le(gaIFLGetProduct(&fl), n*1.00005);
+	
+	/**
+	 * Attempt exact factorization of 7438473388800000000, 5-smooth constraint.
+	 * It is a large, 5-smooth number. This should exercise the 5-smooth
+	 * factorization path.
+	 */
+	
+	n =  7438473388800000000ULL;
+	ck_assert_int_ne (gaIFactorize(n,         0,     5, &fl), 0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 14);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    3ULL), 19);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  8);
+	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 5);
+	ck_assert_uint_eq(gaIFLGetProduct(&fl), n);
+	
+	/**
+	 * Attempt approximate factorization of 7438473388799999997, 2-smooth constraint.
+	 * It is a large, non-smooth number. This should exercise the optimal 2-smooth
+	 * factorizer in spite of the available, unlimited slack.
+	 */
+	
+	n =  7438473388799999997ULL;
+	ck_assert_int_ne (gaIFactorize(n,        -1,      2, &fl), 0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 63);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    3ULL),  0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  0);
+	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 2);
+	ck_assert_uint_eq(gaIFLGetProduct(&fl),  9223372036854775808ULL);
+	
+	/**
+	 * Attempt approximate factorization of 7438473388799999997, 3-smooth constraint.
+	 * It is a large, non-smooth number. This should exercise the optimal 3-smooth
+	 * factorizer in spite of the available, unlimited slack.
+	 */
+	
+	n =  7438473388799999997ULL;
+	ck_assert_int_ne (gaIFactorize(n,        -1,      3, &fl), 0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 31);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    3ULL), 20);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  0);
+	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 3);
+	ck_assert_uint_eq(gaIFLGetProduct(&fl),  7487812485248974848ULL);
+	
+	/**
+	 * Attempt approximate factorization of 7438473388799999997, 5-smooth constraint.
+	 * It is a large, non-smooth number, but 3 integers above it is a 5-smooth
+	 * integer, 7438473388800000000. This should exercise the optimal 5-smooth
+	 * factorizer in spite of the available, unlimited slack.
+	 */
+	
+	n =  7438473388799999997ULL;
+	ck_assert_int_ne (gaIFactorize(n,        -1,     5, &fl), 0);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 14);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    3ULL), 19);
+	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  8);
+	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 5);
+	ck_assert_uint_eq(gaIFLGetProduct(&fl), 7438473388800000000ULL);
+	
+	/**
+	 * Toughest challenge: Attempt very tight approximate factorization of
+	 * 9876543210987654321 with .01% slack and 43-smooth constraint.
+	 * 
+	 * This forces a bypass of the optimal 5-smooth factorizers and heavily
+	 * exercises the nextI:, subfactorize:, primetest: and newX jumps and
+	 * calculations.
+	 * 
+	 * Expected PASS, "reasonably fast".
+	 */
+	
+	n =  9876543210987654321ULL;
+	ck_assert_int_ne (gaIFactorize(n, n*1.0001,    43, &fl), 0);
+	ck_assert_uint_ge(gaIFLGetProduct(&fl), n);
+	ck_assert_uint_le(gaIFLGetProduct(&fl), n*1.0001);
+	ck_assert_uint_le(gaIFLGetGreatestFactor(&fl), 43);
 }END_TEST
 
 START_TEST(test_scheduler){
@@ -278,6 +457,9 @@ Suite *get_suite(void){
 	Suite *s  = suite_create("util_integerfactoring");
 	TCase *tc = tcase_create("All");
 	
+	tcase_set_timeout(tc, 10.0);
+	
+	tcase_add_test(tc, test_primalitychecker);
 	tcase_add_test(tc, test_integerfactorization);
 	tcase_add_test(tc, test_scheduler);
 	

--- a/tests/check_util_integerfactoring.c
+++ b/tests/check_util_integerfactoring.c
@@ -97,12 +97,12 @@ START_TEST(test_primalitychecker){
 START_TEST(test_integerfactorization){
 	ga_factor_list fl;
 	uint64_t       n;
-	
+
 	/**
 	 * Attempt exact factorization for 2^64-1, no k-smoothness constraint.
 	 * Expected PASS with 3*5*17*257*641*65537*6700417
 	 */
-	
+
 	n = 18446744073709551615ULL;
 	ck_assert_int_ne (gaIFactorize(n,         0,     0, &fl), 0);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    3ULL),  1);
@@ -113,34 +113,34 @@ START_TEST(test_integerfactorization){
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                65537ULL),  1);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,              6700417ULL),  1);
 	ck_assert_uint_eq(gaIFLGetProduct(&fl), n);
-	
+
 	/**
 	 * Attempt exact factorization for 2^64-1, 4096-smooth constraint.
 	 * Expected FAIL, because 2^64-1 possesses prime factors in excess of 4096.
 	 */
-	
+
 	n = 18446744073709551615ULL;
 	ck_assert_int_eq (gaIFactorize(n,         0,  4096, &fl), 0);
-	
+
 	/**
 	 * Attempt approximate factorization for 2^64-1, no k-smoothness constraint.
 	 * Unlimited growth permitted.
 	 * Expected PASS, since 2^64-1 rounds up to 2^64 and 2^64 trivially factorizes.
 	 */
-	
+
 	n = 18446744073709551615ULL;
 	ck_assert_int_ne (gaIFactorize(n,        -1,     0, &fl), 0);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 64);
 	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 2);
 	ck_assert_int_ne (gaIFLIsOverflowed(&fl), 0);
-	
+
 	/**
 	 * Attempt exact factorization for 2196095973992233039, no k-smoothness constraint.
 	 * 2196095973992233039 is a large, highly non-smooth number, with three enormous
 	 * factors.
 	 * Expected PASS *very quickly*, since it factorizes as 1299817*1299821*1299827
 	 */
-	
+
 	n =  2196095973992233039ULL;
 	ck_assert_int_ne (gaIFactorize(n,         0,     0, &fl), 0);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,              1299817ULL),  1);
@@ -148,27 +148,27 @@ START_TEST(test_integerfactorization){
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,              1299827ULL),  1);
 	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 1299827);
 	ck_assert_uint_eq(gaIFLGetProduct(&fl), n);
-	
+
 	/**
 	 * Attempt approximate factorization for 2196095973992233039, 16-smooth constraint.
 	 * 2196095973992233039 is a large, highly non-smooth number, with three enormous
 	 * factors. It is not 64-smooth, so code paths that attempt approximate
 	 * factorization within the growth limits (.005%) are exercised.
-	 * 
+	 *
 	 * Expected PASS *relatively quickly*.
 	 */
-	
+
 	n =  2196095973992233039ULL;
 	ck_assert_int_ne (gaIFactorize(n, n*1.00005,    16, &fl), 0);
 	ck_assert_uint_ge(gaIFLGetProduct(&fl), n);
 	ck_assert_uint_le(gaIFLGetProduct(&fl), n*1.00005);
-	
+
 	/**
 	 * Attempt exact factorization of 7438473388800000000, 5-smooth constraint.
 	 * It is a large, 5-smooth number. This should exercise the 5-smooth
 	 * factorization path.
 	 */
-	
+
 	n =  7438473388800000000ULL;
 	ck_assert_int_ne (gaIFactorize(n,         0,     5, &fl), 0);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 14);
@@ -176,13 +176,13 @@ START_TEST(test_integerfactorization){
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  8);
 	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 5);
 	ck_assert_uint_eq(gaIFLGetProduct(&fl), n);
-	
+
 	/**
 	 * Attempt approximate factorization of 7438473388799999997, 2-smooth constraint.
 	 * It is a large, non-smooth number. This should exercise the optimal 2-smooth
 	 * factorizer in spite of the available, unlimited slack.
 	 */
-	
+
 	n =  7438473388799999997ULL;
 	ck_assert_int_ne (gaIFactorize(n,        -1,      2, &fl), 0);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 63);
@@ -190,13 +190,13 @@ START_TEST(test_integerfactorization){
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  0);
 	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 2);
 	ck_assert_uint_eq(gaIFLGetProduct(&fl),  9223372036854775808ULL);
-	
+
 	/**
 	 * Attempt approximate factorization of 7438473388799999997, 3-smooth constraint.
 	 * It is a large, non-smooth number. This should exercise the optimal 3-smooth
 	 * factorizer in spite of the available, unlimited slack.
 	 */
-	
+
 	n =  7438473388799999997ULL;
 	ck_assert_int_ne (gaIFactorize(n,        -1,      3, &fl), 0);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 31);
@@ -204,14 +204,14 @@ START_TEST(test_integerfactorization){
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  0);
 	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 3);
 	ck_assert_uint_eq(gaIFLGetProduct(&fl),  7487812485248974848ULL);
-	
+
 	/**
 	 * Attempt approximate factorization of 7438473388799999997, 5-smooth constraint.
 	 * It is a large, non-smooth number, but 3 integers above it is a 5-smooth
 	 * integer, 7438473388800000000. This should exercise the optimal 5-smooth
 	 * factorizer in spite of the available, unlimited slack.
 	 */
-	
+
 	n =  7438473388799999997ULL;
 	ck_assert_int_ne (gaIFactorize(n,        -1,     5, &fl), 0);
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    2ULL), 14);
@@ -219,18 +219,18 @@ START_TEST(test_integerfactorization){
 	ck_assert_int_eq (gaIFLGetFactorPower(&fl,                    5ULL),  8);
 	ck_assert_uint_eq(gaIFLGetGreatestFactor(&fl), 5);
 	ck_assert_uint_eq(gaIFLGetProduct(&fl), 7438473388800000000ULL);
-	
+
 	/**
 	 * Toughest challenge: Attempt very tight approximate factorization of
 	 * 9876543210987654321 with .01% slack and 43-smooth constraint.
-	 * 
+	 *
 	 * This forces a bypass of the optimal 5-smooth factorizers and heavily
 	 * exercises the nextI:, subfactorize:, primetest: and newX jumps and
 	 * calculations.
-	 * 
+	 *
 	 * Expected PASS, "reasonably fast".
 	 */
-	
+
 	n =  9876543210987654321ULL;
 	ck_assert_int_ne (gaIFactorize(n, n*1.0001,    43, &fl), 0);
 	ck_assert_uint_ge(gaIFLGetProduct(&fl), n);
@@ -243,36 +243,36 @@ START_TEST(test_scheduler){
 	uint64_t maxBTot  =       1024, maxBInd[] = {      1024,      1024,        64},
 	         maxGTot  = 0xFFFFFFFF, maxGInd[] = {2147483647,     65535,     65535},
 	         warpSize =         32;
-	
+
 	int                warpAxis;
 	uint64_t           dims[3];
 	ga_factor_list     factBS[3], factGS[3], factCS[3];
 	unsigned long long intbBS[3], intbGS[3], intbCS[3];
 	unsigned long long intaBS[3], intaGS[3], intaCS[3];
-	
+
 	/**
 	 * NOTE: If you want to view befores-and-afters of scheduling, #define PRINT
 	 *       to something non-0.
 	 */
 #define PRINT 0
-	
+
 	/**
-	 * 
+	 *
 	 * Testcase: (895,1147,923) job, warpSize on axis 0.
-	 * 
+	 *
 	 */
-	
+
 	{
 		warpAxis       =          0;
 		dims[0]        =        895;
 		dims[1]        =       1141;
 		dims[2]        =        923;
 		dims[warpAxis] = (dims[warpAxis]+warpSize-1) / warpSize;
-		
+
 		/**
 		 * Factorization job must be successful.
 		 */
-		
+
 		ck_assert(gaIFactorize(warpAxis==0?warpSize:1,           0, maxBInd[0], factBS+0));
 		ck_assert(gaIFactorize(warpAxis==1?warpSize:1,           0, maxBInd[1], factBS+1));
 		ck_assert(gaIFactorize(warpAxis==2?warpSize:1,           0, maxBInd[2], factBS+2));
@@ -282,7 +282,7 @@ START_TEST(test_scheduler){
 		ck_assert(gaIFactorize(               dims[0], dims[0]*1.1, maxBInd[0], factCS+0));
 		ck_assert(gaIFactorize(               dims[1], dims[1]*1.1, maxBInd[1], factCS+1));
 		ck_assert(gaIFactorize(               dims[2], dims[2]*1.1, maxBInd[2], factCS+2));
-		
+
 		intbBS[0] = gaIFLGetProduct(factBS+0);
 		intbBS[1] = gaIFLGetProduct(factBS+1);
 		intbBS[2] = gaIFLGetProduct(factBS+2);
@@ -292,20 +292,20 @@ START_TEST(test_scheduler){
 		intbCS[0] = gaIFLGetProduct(factCS+0);
 		intbCS[1] = gaIFLGetProduct(factCS+1);
 		intbCS[2] = gaIFLGetProduct(factCS+2);
-		
+
 		/**
 		 * Ensure that factorization only *increases* the size of the problem.
 		 */
-		
+
 		ck_assert_uint_ge(intbCS[0], dims[0]);
 		ck_assert_uint_ge(intbCS[1], dims[1]);
 		ck_assert_uint_ge(intbCS[2], dims[2]);
-		
-		
+
+
 		/**
 		 * Run scheduler.
 		 */
-		
+
 #if PRINT
 		printf("Before:\n");
 		printf("BS: (%6llu, %6llu, %6llu)\n", intbBS[0], intbBS[1], intbBS[2]);
@@ -328,21 +328,21 @@ START_TEST(test_scheduler){
 		printf("GS: (%6llu, %6llu, %6llu)\n", intaGS[0], intaGS[1], intaGS[2]);
 		printf("CS: (%6llu, %6llu, %6llu)\n", intaCS[0], intaCS[1], intaCS[2]);
 #endif
-		
+
 		/**
 		 * Scheduling is only about moving factors between block/grid/chunk factor
 		 * lists. Therefore, the three dimensions must not have changed size.
 		 */
-		
+
 		ck_assert_uint_eq(intbBS[0]*intbGS[0]*intbCS[0], intaBS[0]*intaGS[0]*intaCS[0]);
 		ck_assert_uint_eq(intbBS[1]*intbGS[1]*intbCS[1], intaBS[1]*intaGS[1]*intaCS[1]);
 		ck_assert_uint_eq(intbBS[2]*intbGS[2]*intbCS[2], intaBS[2]*intaGS[2]*intaCS[2]);
-		
+
 		/**
 		 * Verify that the individual limits and global limits on threads in a
 		 * block and blocks in a grid are met.
 		 */
-		
+
 		ck_assert_uint_le(intaBS[0],                     maxBInd[0]);
 		ck_assert_uint_le(intaBS[1],                     maxBInd[1]);
 		ck_assert_uint_le(intaBS[2],                     maxBInd[2]);
@@ -352,25 +352,25 @@ START_TEST(test_scheduler){
 		ck_assert_uint_le(intaBS[0]*intaBS[1]*intaBS[2], maxBTot);
 		ck_assert_uint_le(intaGS[0]*intaGS[1]*intaGS[2], maxGTot);
 	}
-	
-	
+
+
 	/**
-	 * 
+	 *
 	 * Testcase: (1,1,121632959) job, warpSize on axis 2.
-	 * 
+	 *
 	 */
-	
+
 	{
 		warpAxis       =         2;
 		dims[0]        =         1;
 		dims[1]        =         1;
 		dims[2]        = 121632959;
 		dims[warpAxis] = (dims[warpAxis]+warpSize-1) / warpSize;
-		
+
 		/**
 		 * Factorization job must be successful.
 		 */
-		
+
 		ck_assert(gaIFactorize(warpAxis==0?warpSize:1,           0, maxBInd[0], factBS+0));
 		ck_assert(gaIFactorize(warpAxis==1?warpSize:1,           0, maxBInd[1], factBS+1));
 		ck_assert(gaIFactorize(warpAxis==2?warpSize:1,           0, maxBInd[2], factBS+2));
@@ -380,7 +380,7 @@ START_TEST(test_scheduler){
 		ck_assert(gaIFactorize(               dims[0], dims[0]*1.1, maxBInd[0], factCS+0));
 		ck_assert(gaIFactorize(               dims[1], dims[1]*1.1, maxBInd[1], factCS+1));
 		ck_assert(gaIFactorize(               dims[2], dims[2]*1.1, maxBInd[2], factCS+2));
-		
+
 		intbBS[0] = gaIFLGetProduct(factBS+0);
 		intbBS[1] = gaIFLGetProduct(factBS+1);
 		intbBS[2] = gaIFLGetProduct(factBS+2);
@@ -390,20 +390,20 @@ START_TEST(test_scheduler){
 		intbCS[0] = gaIFLGetProduct(factCS+0);
 		intbCS[1] = gaIFLGetProduct(factCS+1);
 		intbCS[2] = gaIFLGetProduct(factCS+2);
-		
+
 		/**
 		 * Ensure that factorization only *increases* the size of the problem.
 		 */
-		
+
 		ck_assert_uint_ge(intbCS[0], dims[0]);
 		ck_assert_uint_ge(intbCS[1], dims[1]);
 		ck_assert_uint_ge(intbCS[2], dims[2]);
-		
-		
+
+
 		/**
 		 * Run scheduler.
 		 */
-		
+
 #if PRINT
 		printf("Before:\n");
 		printf("BS: (%6llu, %6llu, %6llu)\n", intbBS[0], intbBS[1], intbBS[2]);
@@ -426,21 +426,21 @@ START_TEST(test_scheduler){
 		printf("GS: (%6llu, %6llu, %6llu)\n", intaGS[0], intaGS[1], intaGS[2]);
 		printf("CS: (%6llu, %6llu, %6llu)\n", intaCS[0], intaCS[1], intaCS[2]);
 #endif
-		
+
 		/**
 		 * Scheduling is only about moving factors between block/grid/chunk factor
 		 * lists. Therefore, the three dimensions must not have changed size.
 		 */
-		
+
 		ck_assert_uint_eq(intbBS[0]*intbGS[0]*intbCS[0], intaBS[0]*intaGS[0]*intaCS[0]);
 		ck_assert_uint_eq(intbBS[1]*intbGS[1]*intbCS[1], intaBS[1]*intaGS[1]*intaCS[1]);
 		ck_assert_uint_eq(intbBS[2]*intbGS[2]*intbCS[2], intaBS[2]*intaGS[2]*intaCS[2]);
-		
+
 		/**
 		 * Verify that the individual limits and global limits on threads in a
 		 * block and blocks in a grid are met.
 		 */
-		
+
 		ck_assert_uint_le(intaBS[0],                     maxBInd[0]);
 		ck_assert_uint_le(intaBS[1],                     maxBInd[1]);
 		ck_assert_uint_le(intaBS[2],                     maxBInd[2]);
@@ -457,15 +457,15 @@ START_TEST(test_scheduler){
 Suite *get_suite(void){
 	Suite *s  = suite_create("util_integerfactoring");
 	TCase *tc = tcase_create("All");
-	
+
 	tcase_set_timeout(tc, 10.0);
-	
+
 	tcase_add_test(tc, test_primalitychecker);
 	tcase_add_test(tc, test_integerfactorization);
 	tcase_add_test(tc, test_scheduler);
-	
+
 	suite_add_tcase(s, tc);
-	
+
 	return s;
 }
 


### PR DESCRIPTION
Added, for developer usage, a scheduler function that accepts `uint64_t` arguments rather than `ga_factor_list`s.

Also:

- Refactored and improved factorizer logic. In particular, always attempt an optimal 2-, 3- or 5-smooth factorization depending on `k`-smoothness constraint, instead of 2-smooth (round-up-to-next-power-of-2) only. For very large `n`, the next 5-smooth number is usually less than 1% higher. Compare to the next 2-smooth number, which can be as much as 100% higher.
- Many new testcases and extra checks for older testcases.
- Switched to >2x faster primality checker (BPSW).
- Important inline assembler bugfix, for an error causing miscompilation in Release mode.
- Renamed `gaIFLsnprintf()` to `gaIFLsprintf()` and use `sprintf()`, which is a C89 standard library function.
- Bugfixes to broken `gaIFLappend()`, including a mismatch between the header and source function names and an uninitialized variable `j` warning.
- Cleaned whitespace.
