### PR TITLE
Eliminate nearly all GCC warnings under -Wall -Wextra -Wno-unused-parameter.

### DIFF
--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -280,7 +280,7 @@ int GpuArray_index_inplace(GpuArray *a, const ssize_t *starts,
       return GA_VALUE_ERROR;
     }
     if (steps[i] == 0 &&
-	(starts[i] == -1 || starts[i] >= a->dimensions[i])) {
+	(starts[i] == -1 || starts[i] >= (ssize_t)a->dimensions[i])) {
       free(newdims);
       free(newstrs);
       return GA_VALUE_ERROR;
@@ -663,10 +663,10 @@ int GpuArray_reshape_inplace(GpuArray *a, unsigned int nd,
 
     for (ok = oi; ok < oj - 1; ok++) {
       if (ord == GA_F_ORDER) {
-        if (a->strides[ok+1] != a->dimensions[ok]*a->strides[ok])
+        if (a->strides[ok+1] != (ssize_t)a->dimensions[ok]*a->strides[ok])
           goto need_copy;
       } else {
-        if (a->strides[ok] != a->dimensions[ok+1]*a->strides[ok+1])
+        if (a->strides[ok] != (ssize_t)a->dimensions[ok+1]*a->strides[ok+1])
           goto need_copy;
       }
     }
@@ -1125,7 +1125,7 @@ int GpuArray_is_c_contiguous(const GpuArray *a) {
   int i;
 
   for (i = a->nd - 1; i >= 0; i--) {
-    if (a->strides[i] != size) return 0;
+    if (a->strides[i] != (ssize_t)size) return 0;
     // We suppose that overflow will not happen since data has to fit in memory
     size *= a->dimensions[i];
   }
@@ -1137,7 +1137,7 @@ int GpuArray_is_f_contiguous(const GpuArray *a) {
   unsigned int i;
 
   for (i = 0; i < a->nd; i++) {
-    if (a->strides[i] != size) return 0;
+    if (a->strides[i] != (ssize_t)size) return 0;
     // We suppose that overflow will not happen since data has to fit in memory
     size *= a->dimensions[i];
   }

--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -280,7 +280,7 @@ int GpuArray_index_inplace(GpuArray *a, const ssize_t *starts,
       return GA_VALUE_ERROR;
     }
     if (steps[i] == 0 &&
-	(starts[i] == -1 || starts[i] >= (ssize_t)a->dimensions[i])) {
+	(starts[i] == -1 || (size_t)starts[i] >= a->dimensions[i])) {
       free(newdims);
       free(newstrs);
       return GA_VALUE_ERROR;

--- a/src/gpuarray_array_blas.c
+++ b/src/gpuarray_array_blas.c
@@ -370,7 +370,7 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
   int err;
   gpudata **A_datas = NULL, **B_datas = NULL, **C_datas = NULL;
   size_t *A_offsets = NULL, *B_offsets = NULL, *C_offsets = NULL;
-  int i;
+  size_t i;
 
   if (A->typecode != GA_FLOAT && A->typecode != GA_DOUBLE)
     return GA_INVALID_ERROR;

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -871,7 +871,7 @@ static int detect_arch(const char *prefix, char *ret, CUresult *err) {
   *err = get_cc(dev, &major, &minor);
   if (*err != CUDA_SUCCESS) return GA_IMPL_ERROR;
   res = snprintf(ret, sz, "%s%d%d", prefix, major, minor);
-  if (res == -1 || res > sz) return GA_UNSUPPORTED_ERROR;
+  if (res == -1 || res > (ssize_t)sz) return GA_UNSUPPORTED_ERROR;
   return GA_NO_ERROR;
 }
 

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -1453,11 +1453,12 @@ static int cl_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
 
 static const char *cl_error(gpucontext *c) {
   cl_ctx *ctx = (cl_ctx *)c;
-  if (ctx == NULL)
+  if (ctx == NULL){
     return get_error_string(err);
-  else
+  }else{
     ASSERT_CTX(ctx);
     return get_error_string(ctx->err);
+  }
 }
 
 GPUARRAY_LOCAL

--- a/src/gpuarray_util.c
+++ b/src/gpuarray_util.c
@@ -173,7 +173,7 @@ void gpuarray_elemwise_collapse(unsigned int n, unsigned int *_nd,
     int collapse = 1;
     for (k = 0; k < n; k++) {
       collapse &= (strs[k] == NULL ||
-                   strs[k][i - 1] == dims[i] * strs[k][i]);
+                   strs[k][i - 1] == (ssize_t)dims[i] * strs[k][i]);
     }
     if (collapse) {
       dims[i-1] *= dims[i];


### PR DESCRIPTION
Eliminated warnings:

- `-Wsign-compare`
- `-Wempty-body`
- <strike>`-Wunused-parameter`</strike>

As well, a possibly logic fault was identified in `src/gpuarray_buffer_opencl.c` involving lack of braces around the branches of an `if/else`.

GCC now builds libgpuarray almost without any warnings (the exception is `gpuarray_reduction.c`, which is the subject of another PR and separately reports under `-Wmissing-field-initializer` even though in that particular case the usage is intentional and correct).