### PR TITLE
Fix for scheduling in some corner cases.

### DIFF
--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -499,8 +499,11 @@ int GpuArray_take1(GpuArray *a, const GpuArray *v, const GpuArray *i,
     pl = ls[0];
     ls[0] = ls[1];
     ls[1] = pl;
+    gs[0] = 1;
+  } else {
+    gs[0] = gs[1];
+    gs[1] = 1;
   }
-  gs[0] = 1;
 
   argp = 0;
   GpuKernel_setarg(&k, argp++, a->data);


### PR DESCRIPTION
This makes the case reported at https://github.com/Theano/Theano/issues/5154 go from 
~3.6e-2 per call to ~4.3e-4 per call on my card.

We could maybe gain a few more percent (and avoid other corner cases) with a better scheduling, but I am too tired to finish that.