### PR TITLE
Code added to get PCI Bus ID from a CUDA device.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Build
 build
 Debug
 Release

--- a/pygpu/gpuarray.pxd
+++ b/pygpu/gpuarray.pxd
@@ -87,6 +87,7 @@ cdef extern from "gpuarray/buffer.h":
     int GA_CTX_DISABLE_ALLOCATION_CACHE
 
     int GA_CTX_PROP_DEVNAME
+    int GA_CTX_PROP_PCIBUSID
     int GA_CTX_PROP_MAXLSIZE
     int GA_CTX_PROP_LMEMSIZE
     int GA_CTX_PROP_NUMPROCS

--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -1016,6 +1016,19 @@ cdef class GpuContext:
                 free(tmp)
             return res
 
+    property pcibusid:
+        "Device PCI Bus ID for this context"
+        def __get__(self):
+            cdef char *tmp
+            cdef unicode res
+
+            ctx_property(self, GA_CTX_PROP_PCIBUSID, &tmp)
+            try:
+                res = tmp.decode('ascii')
+            finally:
+                free(tmp)
+            return res
+
     property maxlsize:
         "Maximum size of thread block (local size) for this context"
         def __get__(self):

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -680,6 +680,15 @@ GPUARRAY_PUBLIC gpucontext *gpukernel_context(gpukernel *k);
  */
 #define GA_CTX_PROP_COMM_OPS  18
 
+/**
+ * Get the device PCI Bus ID for the context.
+ *
+ * \note The returned string is allocated and must be freed by the caller.
+ *
+ * Type: `char *`
+ */
+#define GA_CTX_PROP_PCIBUSID 19
+
 /* Start at 512 for GA_BUFFER_PROP_ */
 #define GA_BUFFER_PROP_START  512
 

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1502,6 +1502,30 @@ static int cuda_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
     *((char **)res) = s;
     cuda_exit(ctx);
     return GA_NO_ERROR;
+  
+  case GA_CTX_PROP_PCIBUSID:
+    cuda_enter(ctx);
+    ctx->err = cuCtxGetDevice(&id);
+    if (ctx->err != CUDA_SUCCESS) {
+      cuda_exit(ctx);
+      return GA_IMPL_ERROR;
+    }
+    s = malloc(13);
+    if (s == NULL) {
+      cuda_exit(ctx);
+      return GA_MEMORY_ERROR;
+    }
+    ctx->err = cudaDeviceGetPCIBusId(s, 13, id);
+    if (ctx->err != CUDA_SUCCESS) {
+      /* PS: in GA_CTX_PROP_DEVNAME above, s is not freed here.
+       * I think it should be freed, isn't it ? */
+      free(s);
+      cuda_exit(ctx);
+      return GA_IMPL_ERROR;
+    }
+    *((char **)res) = s;
+    cuda_exit(ctx);
+    return GA_NO_ERROR;
 
   case GA_CTX_PROP_MAXLSIZE:
     cuda_enter(ctx);

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1515,7 +1515,7 @@ static int cuda_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
       cuda_exit(ctx);
       return GA_MEMORY_ERROR;
     }
-    ctx->err = cudaDeviceGetPCIBusId(s, 13, id);
+    ctx->err = cuDeviceGetPCIBusId(s, 13, id);
     if (ctx->err != CUDA_SUCCESS) {
       /* PS: in GA_CTX_PROP_DEVNAME above, s is not freed here.
        * I think it should be freed, isn't it ? */

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -1152,6 +1152,14 @@ static int cl_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
     size_t *psz;
     cl_device_id id;
     cl_uint ui;
+    /* For GA_CTX_PROP_PCIBUSID (currently desactivated).
+     * According to http://www.makelinux.net/ldd3/chp-12-sect-1
+     * (accessed on 2016/11/09:15h41 EST):
+     * domain: 16 bits, bus: 8 bits, device: 5 bits, function: 3 bits. */
+    /*
+    uint32_t* busid;
+    uint32_t domain = 0, bus = 0, device = 0, function = 0;
+    */
 
   case GA_CTX_PROP_DEVNAME:
     ctx->err = clGetContextInfo(ctx->ctx, CL_CONTEXT_DEVICES, sizeof(id),
@@ -1171,6 +1179,46 @@ static int cl_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
     }
     *((char **)res) = s;
     return GA_NO_ERROR;
+
+  case GA_CTX_PROP_PCIBUSID:
+    /* PS: Currently desactivated. This does not print the same
+     * Bus ID as cuda and nvidia-smi. For the moment, I don't find
+     * which info will display the correct PCI Bus ID with OpenCL. */
+    /*
+    ctx->err = clGetContextInfo(ctx->ctx, CL_CONTEXT_DEVICES, sizeof(id),
+                                &id, NULL);
+    if (ctx->err != CL_SUCCESS)
+      return GA_IMPL_ERROR;
+    ctx->err = clGetDeviceInfo(id, CL_DEVICE_VENDOR_ID, 0, NULL, &sz);
+    if (ctx->err != CL_SUCCESS)
+      return GA_IMPL_ERROR;
+    if(sz != 4)
+      return GA_IMPL_ERROR;
+    busid = malloc(sz);
+    if (busid == NULL)
+      return GA_MEMORY_ERROR;
+    ctx->err = clGetDeviceInfo(id, CL_DEVICE_VENDOR_ID, sz, busid, NULL);
+    if (ctx->err != CL_SUCCESS) {
+      free(busid);
+      return GA_IMPL_ERROR;
+    }
+    domain = *busid >> (32-16);
+    bus = *busid << 16 >> (32-8);
+    device = *busid << 24 >> (32-5);
+    function = *busid << 29 >> (32-3);
+    free(busid);
+    s = malloc(13);
+    sprintf(s, "%04x", domain);
+    sprintf(s + 5, "%02x", bus);
+    sprintf(s + 8, "%02x", device);
+    sprintf(s + 11, "%01x", function);
+    s[4] = s[7] = ':';
+    s[10] = '.';
+    *((char **)res) = s;
+    return GA_NO_ERROR;
+    */
+    *((void **)res) = NULL;
+    return GA_DEVSUP_ERROR;
 
   case GA_CTX_PROP_MAXLSIZE:
     ctx->err = clGetContextInfo(ctx->ctx, CL_CONTEXT_DEVICES, sizeof(id),

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -1152,14 +1152,6 @@ static int cl_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
     size_t *psz;
     cl_device_id id;
     cl_uint ui;
-    /* For GA_CTX_PROP_PCIBUSID (currently desactivated).
-     * According to http://www.makelinux.net/ldd3/chp-12-sect-1
-     * (accessed on 2016/11/09:15h41 EST):
-     * domain: 16 bits, bus: 8 bits, device: 5 bits, function: 3 bits. */
-    /*
-    uint32_t* busid;
-    uint32_t domain = 0, bus = 0, device = 0, function = 0;
-    */
 
   case GA_CTX_PROP_DEVNAME:
     ctx->err = clGetContextInfo(ctx->ctx, CL_CONTEXT_DEVICES, sizeof(id),
@@ -1181,42 +1173,7 @@ static int cl_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
     return GA_NO_ERROR;
 
   case GA_CTX_PROP_PCIBUSID:
-    /* PS: Currently desactivated. This does not print the same
-     * Bus ID as cuda and nvidia-smi. For the moment, I don't find
-     * which info will display the correct PCI Bus ID with OpenCL. */
-    /*
-    ctx->err = clGetContextInfo(ctx->ctx, CL_CONTEXT_DEVICES, sizeof(id),
-                                &id, NULL);
-    if (ctx->err != CL_SUCCESS)
-      return GA_IMPL_ERROR;
-    ctx->err = clGetDeviceInfo(id, CL_DEVICE_VENDOR_ID, 0, NULL, &sz);
-    if (ctx->err != CL_SUCCESS)
-      return GA_IMPL_ERROR;
-    if(sz != 4)
-      return GA_IMPL_ERROR;
-    busid = malloc(sz);
-    if (busid == NULL)
-      return GA_MEMORY_ERROR;
-    ctx->err = clGetDeviceInfo(id, CL_DEVICE_VENDOR_ID, sz, busid, NULL);
-    if (ctx->err != CL_SUCCESS) {
-      free(busid);
-      return GA_IMPL_ERROR;
-    }
-    domain = *busid >> (32-16);
-    bus = *busid << 16 >> (32-8);
-    device = *busid << 24 >> (32-5);
-    function = *busid << 29 >> (32-3);
-    free(busid);
-    s = malloc(13);
-    sprintf(s, "%04x", domain);
-    sprintf(s + 5, "%02x", bus);
-    sprintf(s + 8, "%02x", device);
-    sprintf(s + 11, "%01x", function);
-    s[4] = s[7] = ':';
-    s[10] = '.';
-    *((char **)res) = s;
-    return GA_NO_ERROR;
-    */
+    /* For the moment, PCI Bus ID is not supported for OpenCL. */
     *((void **)res) = NULL;
     return GA_DEVSUP_ERROR;
 

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -3,10 +3,8 @@
 
 #ifdef __APPLE__
 #include <CUDA/cuda.h>
-#include <CUDA/cuda_runtime_api.h>
 #else
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 #endif
 
 #include <cache.h>

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -3,8 +3,10 @@
 
 #ifdef __APPLE__
 #include <CUDA/cuda.h>
+#include <CUDA/cuda_runtime_api.h>
 #else
 #include <cuda.h>
+#include <cuda_runtime_api.h>
 #endif
 
 #include <cache.h>


### PR DESCRIPTION
**Code added to get PCI Bus ID from a CUDA device.**

Some workaround has been done to get the same thing
from OpenCL, but both OpenCL and CUDA don't print
the same info. So for the moment, getting PCI Bus ID
is available from CUDA and "not supported" for OpenCL
(see commented code (will be removed after reviewing!)).

Recall: PCI Bus ID is printed as:
```domain:bus:device.function```
where domain, bus, device and function
are hexadecimal strings:
domain: 16 bits info (4 characters)
bus: 8 bits info (2 characters)
device: 5 bits info (2 characters)
function: 3 bits info (1 character)

Reference:
http://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html#group__CUDART__DEVICE_1gea264dad3d8c4898e0b82213c0253def
http://www.makelinux.net/ldd3/chp-12-sect-1