### PR TITLE
better error message for CUDA JIT linking

### DIFF
--- a/src/loaders/libcuda.fn
+++ b/src/loaders/libcuda.fn
@@ -18,6 +18,7 @@ DEF_PROC_V2(cuCtxPushCurrent, (CUcontext ctx));
 DEF_PROC_V2(cuCtxPopCurrent, (CUcontext *pctx));
 
 DEF_PROC(cuModuleLoadData, (CUmodule *module, const void *image));
+DEF_PROC(cuModuleLoadDataEx, (CUmodule *module, const void *image, unsigned int numOptions, CUjit_option *options, void **optionValues));
 DEF_PROC(cuModuleUnload, (CUmodule hmod));
 DEF_PROC(cuModuleGetFunction, (CUfunction *hfunc, CUmodule hmod, const char *name));
 

--- a/src/loaders/libcuda.h
+++ b/src/loaders/libcuda.h
@@ -29,6 +29,7 @@ typedef enum CUfunction_attribute_enum CUfunction_attribute;
 typedef enum CUevent_flags_enum CUevent_flags;
 typedef enum CUctx_flags_enum CUctx_flags;
 typedef enum CUipcMem_flags_enum CUipcMem_flags;
+typedef enum CUjit_option_enum CUjit_option;
 
 #define CU_IPC_HANDLE_SIZE 64
 
@@ -182,6 +183,27 @@ enum CUctx_flags_enum {
 
 enum CUipcMem_flags_enum {
   CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS = 0x1
+};
+
+enum CUjit_option_enum {
+    CU_JIT_MAX_REGISTERS = 0,
+    CU_JIT_THREADS_PER_BLOCK,
+    CU_JIT_WALL_TIME,
+    CU_JIT_INFO_LOG_BUFFER,
+    CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES,
+    CU_JIT_ERROR_LOG_BUFFER,
+    CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES,
+    CU_JIT_OPTIMIZATION_LEVEL,
+    CU_JIT_TARGET_FROM_CUCONTEXT,
+    CU_JIT_TARGET,
+    CU_JIT_FALLBACK_STRATEGY,
+    CU_JIT_GENERATE_DEBUG_INFO,
+    CU_JIT_LOG_VERBOSE,
+    CU_JIT_GENERATE_LINE_INFO,
+    CU_JIT_CACHE_MODE,
+    CU_JIT_NEW_SM3X_OPT,
+    CU_JIT_FAST_COMPILE,
+    CU_JIT_NUM_OPTIONS
 };
 
 #endif


### PR DESCRIPTION
For #290.

- Now uses `cuModuleLoadDataEx` to link compiled kernel.

- Linker error during `cuModuleLoadDataEx` will be logged in the same manner as compiler error.

To test this (on linux):

1. rename `/path/to/nvidia-driver/libnvidia-ptxjitcompiler.so*` to something invalid

2. `sudo ldconfig`

3. run `check_elemwise` in C tests to see if error message pops up.

error message for me:
```
CUDA kernel link failure::

Linker error log:
fatal   : Unable to load library 'libnvidia-ptxjitcompiler.so.367.44'
```