### PR TITLE
Fix call of elemwise in the basic case when using scalars.

### DIFF
--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -371,7 +371,7 @@ static int call_basic(GpuElemwise *ge, void **args, size_t n, unsigned int nd,
                       size_t *dims, ssize_t **strs, int call32) {
   GpuKernel *k;
   size_t ls = 0, gs = 0;
-  unsigned int p = 0, i, j;
+  unsigned int p = 0, i, j, l;
   int err;
 
   if (nd == 0) return GA_VALUE_ERROR;
@@ -398,6 +398,8 @@ static int call_basic(GpuElemwise *ge, void **args, size_t n, unsigned int nd,
     if (err != GA_NO_ERROR) goto error;
   }
 
+  /* l is the number of arrays to date */
+  l = 0;
   for (j = 0; j < ge->n; j++) {
     if (is_array(ge->args[j])) {
       GpuArray *v = (GpuArray *)args[j];
@@ -406,9 +408,10 @@ static int call_basic(GpuElemwise *ge, void **args, size_t n, unsigned int nd,
       err = GpuKernel_setarg(k, p++, &v->offset);
       if (err != GA_NO_ERROR) goto error;
       for (i = 0; i < nd; i++) {
-        err = GpuKernel_setarg(k, p++, &strs[j][i]);
+        err = GpuKernel_setarg(k, p++, &strs[l][i]);
         if (err != GA_NO_ERROR) goto error;
       }
+      l++;
     } else {
       err = GpuKernel_setarg(k, p++, args[j]);
       if (err != GA_NO_ERROR) goto error;

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -362,6 +362,78 @@ START_TEST(test_basic_offset) {
 }
 END_TEST
 
+START_TEST(test_basic_scalar) {
+  GpuArray a;
+  GpuArray b;
+  GpuArray c;
+  uint32_t x = 2;
+
+  GpuElemwise *ge;
+
+  static const uint32_t data1[3] = {1, 2, 3};
+  static const uint32_t data2[3] = {4, 5};
+  uint32_t data3[6] = {0};
+
+  size_t dims[2];
+
+  gpuelemwise_arg args[4] = {{0}};
+  void *rargs[4];
+
+  dims[0] = 1;
+  dims[1] = 3;
+
+  ga_assert_ok(GpuArray_empty(&a, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+  ga_assert_ok(GpuArray_write(&a, data1, sizeof(data1)));
+
+  dims[0] = 2;
+  dims[1] = 1;
+
+  ga_assert_ok(GpuArray_empty(&b, ctx, GA_UINT, 2, dims, GA_F_ORDER));
+  ga_assert_ok(GpuArray_write(&b, data2, sizeof(data2)));
+
+  dims[1] = 3;
+
+  ga_assert_ok(GpuArray_empty(&c, ctx, GA_UINT, 2, dims, GA_C_ORDER));
+
+  args[0].name = "a";
+  args[0].typecode = GA_UINT;
+  args[0].flags = GE_READ;
+
+  args[1].name = "x";
+  args[1].typecode = GA_UINT;
+  args[1].flags = GE_SCALAR;
+
+  args[2].name = "b";
+  args[2].typecode = GA_UINT;
+  args[2].flags = GE_READ;
+
+  args[3].name = "c";
+  args[3].typecode = GA_UINT;
+  args[3].flags = GE_WRITE;
+
+  ge = GpuElemwise_new(ctx, "", "c = a + x * b", 4, args, 2, 0);
+
+  ck_assert_ptr_ne(ge, NULL);
+
+  rargs[0] = &a;
+  rargs[1] = &x;
+  rargs[2] = &b;
+  rargs[3] = &c;
+
+  ga_assert_ok(GpuElemwise_call(ge, rargs, GE_BROADCAST));
+
+  ga_assert_ok(GpuArray_read(data3, sizeof(data3), &c));
+
+  ck_assert_int_eq(data3[0], 9);
+  ck_assert_int_eq(data3[1], 10);
+  ck_assert_int_eq(data3[2], 11);
+
+  ck_assert_int_eq(data3[3], 11);
+  ck_assert_int_eq(data3[4], 12);
+  ck_assert_int_eq(data3[5], 13);
+}
+END_TEST
+
 START_TEST(test_basic_remove1) {
   GpuArray a;
   GpuArray b;
@@ -680,6 +752,7 @@ Suite *get_suite(void) {
   tcase_add_checked_fixture(tc, setup, teardown);
   tcase_add_test(tc, test_basic_simple);
   tcase_add_test(tc, test_basic_f16);
+  tcase_add_test(tc, test_basic_scalar);
   tcase_add_test(tc, test_basic_offset);
   tcase_add_test(tc, test_basic_remove1);
   tcase_add_test(tc, test_basic_broadcast);


### PR DESCRIPTION
There was an index bug which would cause the library to crash in that case.  I've fixed it and added a test for that.