### PR TITLE
BLD: add conda recipes

### DIFF
--- a/conda/libgpuarray/build.sh
+++ b/conda/libgpuarray/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+CMAKE=$CONDA_PREFIX/bin/cmake
+
+mkdir -p $SRC_DIR/build && cd $SRC_DIR/build
+$CMAKE $SRC_DIR -DCMAKE_BUILD_TYPE="Release" -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DMPI_LIBRARY=$MPI_LIBRARY
+make && make install

--- a/conda/libgpuarray/meta.yaml
+++ b/conda/libgpuarray/meta.yaml
@@ -1,0 +1,30 @@
+package:
+    name: "libgpuarray"
+    version: "0.6.0rc1"
+
+source:
+    git_url: https://github.com/Theano/libgpuarray.git
+    git_rev: master  # TODO: this is for testing. Change to a version tag when done.
+
+build:
+    number: 0
+    script_env: MPI_LIBRARY
+
+requirements:
+    build:
+        - cmake
+        - gcc               # [linux]
+        - llvm              # [osx]
+        - vs2015_runtime    # [win]
+
+    run:
+        - vs2015_runtime    # [win]
+
+about:
+    home: https://github.com/Theano/libgpuarray
+    license: MIT
+    license_file: LICENSE
+    summary: "Library to manipulate tensors on the GPU."
+
+extra:
+    maintainers:

--- a/conda/libgpuarray/meta.yaml
+++ b/conda/libgpuarray/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: "libgpuarray"
-    version: "0.6.0rc1"
+    version: "0.6.0"
 
 source:
     git_url: https://github.com/Theano/libgpuarray.git

--- a/conda/libgpuarray/meta.yaml
+++ b/conda/libgpuarray/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: "libgpuarray"
-    version: "0.6.0"
+    version: "0.6.1"
 
 source:
     git_url: https://github.com/Theano/libgpuarray.git

--- a/conda/pygpu/build.sh
+++ b/conda/pygpu/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PYTHON $SRC_DIR/setup.py build_ext -I$CONDA_PREFIX/include -L$CONDA_PREFIX/lib
+$CONDA_PREFIX/bin/pip install $SRC_DIR

--- a/conda/pygpu/meta.yaml
+++ b/conda/pygpu/meta.yaml
@@ -1,0 +1,41 @@
+package:
+    name: "pygpu"
+    version: "0.6.0rc1"
+
+source:
+    git_url: https://github.com/Theano/libgpuarray.git
+    git_rev: master  # TODO: this is for testing. Change to a version tag when done.
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - pip
+        - setuptools
+        - cython
+        - mako >=0.7
+        - numpy
+        - libgpuarray ==0.6.0rc1
+
+    run:
+        - python
+        - six
+        - nose
+        - mako >=0.7
+        - numpy
+        - libgpuarray ==0.6.0rc1
+
+test:
+    imports:
+        - pygpu
+
+about:
+    home: https://github.com/Theano/libgpuarray
+    license: MIT
+    license_file: LICENSE
+    summary: "Numpy-like wrapper on libgpuarray for GPU computations"
+
+extra:
+    maintainers:

--- a/conda/pygpu/meta.yaml
+++ b/conda/pygpu/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: "pygpu"
-    version: "0.6.0rc1"
+    version: "0.6.0"
 
 source:
     git_url: https://github.com/Theano/libgpuarray.git
@@ -17,7 +17,7 @@ requirements:
         - cython
         - mako >=0.7
         - numpy
-        - libgpuarray ==0.6.0rc1
+        - libgpuarray ==0.6.0
 
     run:
         - python
@@ -25,7 +25,7 @@ requirements:
         - nose
         - mako >=0.7
         - numpy x.x
-        - libgpuarray ==0.6.0rc1
+        - libgpuarray ==0.6.0
 
 test:
     imports:

--- a/conda/pygpu/meta.yaml
+++ b/conda/pygpu/meta.yaml
@@ -18,6 +18,8 @@ requirements:
         - mako >=0.7
         - numpy
         - libgpuarray ==0.6.1
+        # Avoid mkl download during build phase
+        - nomkl # [not win]
 
     run:
         - python
@@ -30,6 +32,9 @@ requirements:
 test:
     imports:
         - pygpu
+    requires:
+        # Avoid mkl download during testing
+        - nomkl # [not win]
 
 about:
     home: https://github.com/Theano/libgpuarray

--- a/conda/pygpu/meta.yaml
+++ b/conda/pygpu/meta.yaml
@@ -24,7 +24,7 @@ requirements:
         - six
         - nose
         - mako >=0.7
-        - numpy
+        - numpy x.x
         - libgpuarray ==0.6.0rc1
 
 test:

--- a/conda/pygpu/meta.yaml
+++ b/conda/pygpu/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: "pygpu"
-    version: "0.6.0"
+    version: "0.6.1"
 
 source:
     git_url: https://github.com/Theano/libgpuarray.git
@@ -17,7 +17,7 @@ requirements:
         - cython
         - mako >=0.7
         - numpy
-        - libgpuarray ==0.6.0
+        - libgpuarray ==0.6.1
 
     run:
         - python
@@ -25,7 +25,7 @@ requirements:
         - nose
         - mako >=0.7
         - numpy x.x
-        - libgpuarray ==0.6.0
+        - libgpuarray ==0.6.1
 
 test:
     imports:


### PR DESCRIPTION
I saw #163 on the issue tracker and thought it would be a nice project for an evening.

Since your build system differentiates between the C library and the Python bindings, I figured the same split would make sense for conda packages, too. The advantage is that the Python wrapper can *depend* on the C library instead of having to *rebuild* it for every Python version. Instead, only the wrapper itself has to be recompiled.

The recipes are very simple, due to your simple build system (great to have dynamic loaders!), not much that can go wrong in the build phase. To build the conda packages, the following steps are necessary:

0. If necessary, exit from conda environments, builds should be run in the root environment. Enter the top level directory of your `libgpuarray` repo.
1. Build the C library:
   ```
   MPI_LIBRARY=/path/to/libmpi.so conda build conda/libgpuarray
   ```
   The MPI library environment variable is optional. During build, the system will be searched for an MPI library anyway (if left empty), this is just for non-standard locations.
   The conda package is put in the `conda-bld` directory in your Anaconda or Miniconda distribution and will be automatically picked up in the next step as build dependency.
2. Build the Python wrapper for a bunch of Numpy and Python versions:
   ```
   conda build conda/pygpu --python 2.7 --numpy 1.11
   conda build conda/pygpu --python 3.5 --numpy 1.11
   conda build conda/pygpu --python 2.7 --numpy 1.10
   conda build conda/pygpu --python 3.5 --numpy 1.10
   ...
   ```
Done.

Edit: adapted for Numpy version pinning.