### PR TITLE
Stop returning allocated memory from the library to avoid problems on windows

### DIFF
--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -1036,28 +1036,18 @@ cdef class GpuContext:
     property devname:
         "Device name for this context"
         def __get__(self):
-            cdef char *tmp
-            cdef unicode res
+            cdef char tmp[256]
 
-            ctx_property(self, GA_CTX_PROP_DEVNAME, &tmp)
-            try:
-                res = tmp.decode('ascii')
-            finally:
-                free(tmp)
-            return res
+            ctx_property(self, GA_CTX_PROP_DEVNAME, tmp)
+            return tmp.decode('ascii')
 
     property pcibusid:
         "Device PCI Bus ID for this context"
         def __get__(self):
-            cdef char *tmp
-            cdef unicode res
+            cdef char tmp[16]
 
-            ctx_property(self, GA_CTX_PROP_PCIBUSID, &tmp)
-            try:
-                res = tmp.decode('ascii')
-            finally:
-                free(tmp)
-            return res
+            ctx_property(self, GA_CTX_PROP_PCIBUSID, tmp)
+            return tmp.decode('ascii')
 
     property maxlsize:
         "Maximum size of thread block (local size) for this context"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,7 +88,7 @@ set_target_properties(gpuarray PROPERTIES
   INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib
   MACOSX_RPATH OFF
   # This is the shared library version
-  VERSION 0.1
+  VERSION 1.0
   )
 
 add_library(gpuarray-static STATIC ${GPUARRAY_SRC})

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -494,7 +494,9 @@ GPUARRAY_PUBLIC int gpukernel_call(gpukernel *k, unsigned int n,
                                    size_t shared, void **args);
 
 /**
- * Get the kernel binary.
+ * (Deprecated) Get the kernel binary.
+ *
+ * This function is deprecated and will be removed in the next release.
  *
  * This can be use to cache kernel binaries after compilation of a
  * specific device.  The kernel can be recreated by calling
@@ -537,9 +539,7 @@ GPUARRAY_PUBLIC gpucontext *gpukernel_context(gpukernel *k);
 /**
  * Get the device name for the context.
  *
- * \note The returned string is allocated and must be freed by the caller.
- *
- * Type: `char *`
+ * Type: `char [256]`
  */
 #define GA_CTX_PROP_DEVNAME  1
 
@@ -683,9 +683,7 @@ GPUARRAY_PUBLIC gpucontext *gpukernel_context(gpukernel *k);
 /**
  * Get the device PCI Bus ID for the context.
  *
- * \note The returned string is allocated and must be freed by the caller.
- *
- * Type: `char *`
+ * Type: `char [16]`
  */
 #define GA_CTX_PROP_PCIBUSID 19
 

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1389,7 +1389,6 @@ static int cuda_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
   }
 
   switch (prop_id) {
-    char *s;
     CUdevice id;
     int i;
     size_t sz;
@@ -1401,21 +1400,9 @@ static int cuda_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
       cuda_exit(ctx);
       return GA_IMPL_ERROR;
     }
-    /* 256 is what the CUDA API uses so it's good enough for me */
-    s = malloc(256);
-    if (s == NULL) {
-      cuda_exit(ctx);
-      return GA_MEMORY_ERROR;
-    }
-    ctx->err = cuDeviceGetName(s, 256, id);
-    if (ctx->err != CUDA_SUCCESS) {
-      free(s);
-      cuda_exit(ctx);
-      return GA_IMPL_ERROR;
-    }
-    *((char **)res) = s;
+    ctx->err = cuDeviceGetName((char *)res, 256, id);
     cuda_exit(ctx);
-    return GA_NO_ERROR;
+    return (ctx->err != CUDA_SUCCESS) ? GA_IMPL_ERROR : GA_NO_ERROR;
 
   case GA_CTX_PROP_PCIBUSID:
     cuda_enter(ctx);
@@ -1424,20 +1411,9 @@ static int cuda_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
       cuda_exit(ctx);
       return GA_IMPL_ERROR;
     }
-    s = malloc(13);
-    if (s == NULL) {
-      cuda_exit(ctx);
-      return GA_MEMORY_ERROR;
-    }
-    ctx->err = cuDeviceGetPCIBusId(s, 13, id);
-    if (ctx->err != CUDA_SUCCESS) {
-      free(s);
-      cuda_exit(ctx);
-      return GA_IMPL_ERROR;
-    }
-    *((char **)res) = s;
+    ctx->err = cuDeviceGetPCIBusId((char *)res, 13, id);
     cuda_exit(ctx);
-    return GA_NO_ERROR;
+    return (ctx->err != CUDA_SUCCESS) ? GA_IMPL_ERROR : GA_NO_ERROR;
 
   case GA_CTX_PROP_LARGEST_MEMBLOCK:
     *((size_t *)res) = largest_size(ctx);

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -1157,7 +1157,6 @@ static int cl_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
   }
 
   switch (prop_id) {
-    char *s;
     size_t sz;
     size_t *psz;
     cl_device_id id;
@@ -1168,23 +1167,11 @@ static int cl_property(gpucontext *c, gpudata *buf, gpukernel *k, int prop_id,
                                 &id, NULL);
     if (ctx->err != CL_SUCCESS)
       return GA_IMPL_ERROR;
-    ctx->err = clGetDeviceInfo(id, CL_DEVICE_NAME, 0, NULL, &sz);
-    if (ctx->err != CL_SUCCESS)
-      return GA_IMPL_ERROR;
-    s = malloc(sz);
-    if (s == NULL)
-      return GA_MEMORY_ERROR;
-    ctx->err = clGetDeviceInfo(id, CL_DEVICE_NAME, sz, s, NULL);
-    if (ctx->err != CL_SUCCESS) {
-      free(s);
-      return GA_IMPL_ERROR;
-    }
-    *((char **)res) = s;
-    return GA_NO_ERROR;
+    ctx->err = clGetDeviceInfo(id, CL_DEVICE_NAME, 256, (char *)res, NULL);
+    return (ctx->err != CL_SUCCESS) ? GA_IMPL_ERROR : GA_NO_ERROR;
 
   case GA_CTX_PROP_PCIBUSID:
     /* For the moment, PCI Bus ID is not supported for OpenCL. */
-    *((void **)res) = NULL;
     return GA_DEVSUP_ERROR;
 
   case GA_CTX_PROP_MAXLSIZE:


### PR DESCRIPTION
Comes with a major bump since we break the interface for older clients (not that I know of any).