### PR TITLE
Fix vs2013 syntax error

### DIFF
--- a/src/gpuarray/config.h
+++ b/src/gpuarray/config.h
@@ -29,6 +29,8 @@
 #include <stddef.h>
 #if _MSC_VER < 1600
 #include <gpuarray/wincompat/stdint.h>
+#else
+#include <stdint.h>    
 #endif
 #define ssize_t intptr_t
 #define SSIZE_MAX INTPTR_MAX


### PR DESCRIPTION
This should fix the compilation errors in #317, it can get me pass the build stage at least, there're still other issues, but that's another story...