### PR TITLE
Disk cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 # -Wall is unbelieveably noisy with Visual Studio:
 # http://stackoverflow.com/q/4001736/3257826
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W4 -D_CRT_SECURE_NO_WARNINGS")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W3 -D_CRT_SECURE_NO_WARNINGS")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 # -Wall is unbelieveably noisy with Visual Studio:
 # http://stackoverflow.com/q/4001736/3257826
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W4")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W4 -D_CRT_SECURE_NO_WARNINGS")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 # -Wall is unbelieveably noisy with Visual Studio:
 # http://stackoverflow.com/q/4001736/3257826
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W3 -D_CRT_SECURE_NO_WARNINGS")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W3")
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 endif()

--- a/bin/gpuarray-cache
+++ b/bin/gpuarray-cache
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import os
+
+def clean(max_size):
+    content = []
+    for root, dirs, files in os.walk(os.environ.get('GPUARRAY_CACHE',
+                                                    '~/.gpuarray/cache/')):
+        for file in files:
+            fpath = os.path.join(root, file)
+            st = os.stat(fpath)
+            content.append((st.st_atime, st.st_size, fpath))
+
+    content.sort()
+    cur_size = 0
+    for _, size, path in content:
+        cur_size += size
+        if cur_size > max_size:
+            os.remove(path)
+
+
+SUFFIXES = {'B': 1, 'K': 1 << 10, 'M': 1 < 20, 'G': 1 << 30, 'T': 1 << 40,
+            'P': 1 << 50, 'E': 1 << 60, 'Z': 1 << 70, 'Y': 1 << 80}
+
+
+def get_size(s):
+    i = 0
+    while i < len(s) and (s[i].isdigit() or s[i] == '.'):
+        i += 1
+    num = s[:i]
+    suf = s[i:]
+    num = float(num)
+    if suf != "":
+        letter = suf.strip().upper()
+        if letter not in SUFFIXES:
+            raise ValueError("can't interpret %r" % init)
+        mult = SUFFIXES[letter]
+    else:
+        mult = 0
+    return int(num * mult)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='libgpuarray cache maintenance utility')
+    parser.add_argument('-s', '--max_size', help='Set the maximum size for pruning')
+    args = parser.parse_args()
+
+    clean(get_size(args.max_size))
+

--- a/bin/gpuarray-cache
+++ b/bin/gpuarray-cache
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 import os
+import sys
 
-def clean(max_size):
+def clean(max_size, path):
     content = []
-    for root, dirs, files in os.walk(os.environ.get('GPUARRAY_CACHE',
-                                                    '~/.gpuarray/cache/')):
+    for root, dirs, files in os.walk(path):
         for file in files:
             fpath = os.path.join(root, file)
             st = os.stat(fpath)
@@ -25,18 +25,18 @@ SUFFIXES = {'B': 1, 'K': 1 << 10, 'M': 1 << 20, 'G': 1 << 30, 'T': 1 << 40,
 
 def get_size(s):
     i = 0
-    while i < len(s) and (s[i].isdigit() or s[i] == '.'):
-        i += 1
-    num = s[:i]
-    suf = s[i:]
+    s = s.strip()
+    if s[-1].upper() in SUFFIXES:
+        num = s[:-1]
+        suf = s[-1].upper()
+    else:
+        num = s
+        suf = ""
     num = float(num)
     if suf != "":
-        letter = suf.strip().upper()
-        if letter not in SUFFIXES:
-            raise ValueError("can't interpret %r" % init)
-        mult = SUFFIXES[letter]
+        mult = SUFFIXES[suf]
     else:
-        mult = 0
+        mult = 1
     return int(num * mult)
 
 
@@ -46,6 +46,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='libgpuarray cache maintenance utility')
     parser.add_argument('-s', '--max_size', help='Set the maximum size for pruning (in bytes with suffixes: K, M, G, ...)')
     args = parser.parse_args()
+    path = os.environ.get('GPUARRAY_CACHE_PATH', None)
+    if path is None:
+        print("You need to set GPUARRAY_CACHE_PATH so that this programs knows which path to clean.")
+        sys.exit(1)
 
-    clean(get_size(args.max_size))
+    clean(get_size(args.max_size), path)
 

--- a/bin/gpuarray-cache
+++ b/bin/gpuarray-cache
@@ -19,7 +19,7 @@ def clean(max_size):
             os.remove(path)
 
 
-SUFFIXES = {'B': 1, 'K': 1 << 10, 'M': 1 < 20, 'G': 1 << 30, 'T': 1 << 40,
+SUFFIXES = {'B': 1, 'K': 1 << 10, 'M': 1 << 20, 'G': 1 << 30, 'T': 1 << 40,
             'P': 1 << 50, 'E': 1 << 60, 'Z': 1 << 70, 'Y': 1 << 80}
 
 
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(description='libgpuarray cache maintenance utility')
-    parser.add_argument('-s', '--max_size', help='Set the maximum size for pruning')
+    parser.add_argument('-s', '--max_size', help='Set the maximum size for pruning (in bytes with suffixes: K, M, G, ...)')
     args = parser.parse_args()
 
     clean(get_size(args.max_size))

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,6 @@
+del bld
+mkdir bld
+cd bld
+cmake .. -G "NMake Makefiles"
+cmake --build . --config Release
+cd ..

--- a/make.bat
+++ b/make.bat
@@ -1,3 +1,7 @@
+REM This helps repetitive builds on windows
+REM It needs the compiler you want to use to be available in the shell
+REM and it will build a release version
+
 del bld
 mkdir bld
 cd bld

--- a/make.bat
+++ b/make.bat
@@ -1,6 +1,6 @@
 del bld
 mkdir bld
 cd bld
-cmake .. -G "NMake Makefiles"
+cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release
 cmake --build . --config Release
 cd ..

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if sys.platform == 'win32' and not os.getenv('CONDA_BUILD'):
     current_dir = os.path.abspath(os.path.dirname(__file__))
     include_dirs += [os.path.join(current_dir, 'src')]
 
-    default_bin_dir = os.path.join(current_dir, 'lib', 'Release')
+    default_bin_dir = os.path.join(current_dir, 'lib')
     if not os.path.isdir(default_bin_dir):
         raise RuntimeError('default binary dir {} does not exist, you may need to build the C library in release mode'.format(default_bin_dir))
     library_dirs += [default_bin_dir]

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ have_cython = False
 
 MAJOR = 0
 MINOR = 6
-PATCH = 2
-SUFFIX = ''
+PATCH = 3
+SUFFIX = '.dev0' # include the '.'
 FULLVERSION = '%d.%d.%d%s' % (MAJOR, MINOR, PATCH, SUFFIX)
 
 try:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ endmacro()
 set(_GPUARRAY_SRC
 cache/lru.c
 cache/twoq.c
+cache/disk.c
 gpuarray_types.c
 gpuarray_error.c
 gpuarray_util.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ set_target_properties(gpuarray PROPERTIES
   INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib
   MACOSX_RPATH OFF
   # This is the shared library version
-  VERSION 2.0
+  VERSION 2.1
   )
 
 add_library(gpuarray-static STATIC ${GPUARRAY_SRC})

--- a/src/cache.h
+++ b/src/cache.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <gpuarray/config.h>
 #include "private_config.h"
+#include "util/strb.h"
 
 typedef void *cache_key_t;
 typedef void *cache_value_t;
@@ -12,6 +13,11 @@ typedef int (*cache_eq_fn)(cache_key_t, cache_key_t);
 typedef uint32_t (*cache_hash_fn)(cache_key_t);
 typedef void (*cache_freek_fn)(cache_key_t);
 typedef void (*cache_freev_fn)(cache_value_t);
+
+typedef int (*kwrite_fn)(strb *res, cache_key_t key);
+typedef int (*vwrite_fn)(strb *res, cache_value_t val);
+typedef cache_key_t (*kread_fn)(const strb *b);
+typedef cache_value_t (*vread_fn)(const strb *b);
 
 typedef struct _cache cache;
 
@@ -77,6 +83,10 @@ cache *cache_twoq(size_t hot_size, size_t warm_size,
                   size_t cold_size, size_t elasticity,
                   cache_eq_fn keq, cache_hash_fn khash,
                   cache_freek_fn kfree, cache_freev_fn vfree);
+
+cache *cache_disk(const char *dirpath, cache *mem,
+                  kwrite_fn kwrite, vwrite_fn vwrite,
+                  kread_fn kread, vread_fn vread);
 
 /* API functions */
 static inline int cache_add(cache *c, cache_key_t k, cache_value_t v) {

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -8,15 +8,9 @@
 
 #include "cache.h"
 #include "private_config.h"
-#include "util/strb.h"
 #include "util/skein.h"
 
 #define HEXP_LEN (128 + 2)
-
-typedef int (*kwrite_fn)(strb *res, cache_key_t key);
-typedef int (*vwrite_fn)(strb *res, cache_value_t val);
-typedef cache_key_t (*kread_fn)(const strb *b);
-typedef cache_value_t (*vread_fn)(const strb *b);
 
 typedef struct _disk_cache {
   cache c;

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -1,0 +1,301 @@
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+
+#include "cache.h"
+#include "private_config.h"
+#include "util/strb.h"
+#include "util/skein.h"
+
+#define HEXP_LEN (128 + 2)
+
+typedef int (*kwrite_fn)(strb *res, cache_key_t key);
+typedef int (*vwrite_fn)(strb *res, cache_value_t val);
+typedef cache_key_t (*kread_fn)(const strb *b);
+typedef cache_value_t (*vread_fn)(const strb *b);
+
+typedef struct _disk_cache {
+  cache c;
+  cache * mem;
+  kwrite_fn kwrite;
+  vwrite_fn vwrite;
+  kread_fn kread;
+  vread_fn vread;
+  int dirfd;
+} disk_cache;
+
+
+static unsigned long long ntohull(const char *in) {
+  return ((unsigned long long)in[0] << 56 | (unsigned long long)in[1] << 48 |
+          (unsigned long long)in[2] << 40 | (unsigned long long)in[3] << 32 |
+          (unsigned long long)in[4] << 24 | (unsigned long long)in[5] << 16 |
+          (unsigned long long)in[6] << 8 | (unsigned long long)in[7]);
+}
+
+static void htonull(unsigned long long in, char *out) {
+  out[0] = in >> 56;
+  out[1] = in >> 48;
+  out[2] = in >> 40;
+  out[3] = in >> 32;
+  out[4] = in >> 24;
+  out[5] = in >> 16;
+  out[6] = in >> 8;
+  out[7] = in;
+}
+
+static int mkstempat(int dfd, char *template) {
+  static const char letters[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  size_t length;
+  char *XXXXXX;
+  struct timeval tv;
+  unsigned long long  randnum, working;
+  int i, tries, fd;
+
+  length = strlen(template);
+  if (length < 6) {
+    errno = EINVAL;
+    return -1;
+  }
+  XXXXXX = template + length - 6;
+  if (strcmp(XXXXXX, "XXXXXX") != 0) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  /* This is kind of crappy, but the point is to not step on each
+     other's feet */
+  gettimeofday(&tv, NULL);
+  randnum = ((unsigned long long) tv.tv_usec << 16) ^ tv.tv_sec ^ getpid();
+
+  for (tries = 0; tries < TMP_MAX; tries++) {
+    for (working = randnum, i = 0; i < 6; i++) {
+      XXXXXX[i] = letters[working % 62];
+      working /= 62;
+    }
+    fd = openat(dfd, template, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd >= 0 || (errno != EEXIST && errno != EISDIR))
+      return fd;
+
+    randnum += (tv.tv_usec >> 10) & 0xfff;
+  }
+  errno = EEXIST;
+  return -1;
+}
+
+static int key_path(disk_cache *c, const cache_key_t key, char *out) {
+  strb kb = STRB_STATIC_INIT;
+  unsigned char hash[64];
+  int i;
+
+  if (c->kwrite(&kb, key)) return -1;
+  if (Skein_512((unsigned char *)kb.s, kb.l, hash)) return -1;
+  if (snprintf(out, 6, "%02x%02x/%02x%02x",
+               hash[0], hash[1], hash[2], hash[3]) != 5)
+    return -1;
+  for (i = 4; i < 64; i += 4) {
+    if (snprintf(out+(i * 2 + 1), 9, "%02x%02x%02x%02x",
+                 hash[i], hash[i+1], hash[i+2], hash[i+3]) != 8)
+      return -1;
+  }
+  return 0;
+}
+
+static int write_entry(disk_cache *c, const cache_key_t k,
+                       const cache_value_t v) {
+  char hexp[HEXP_LEN];
+  char tmp_path[] = "tmp.XXXXXXXX";
+  strb b = STRB_STATIC_INIT;
+  size_t kl, vl;
+  int fd, err;
+
+  if (key_path(c, k, hexp)) return -1;
+
+  if (!strb_ensure(&b, 16)) return -1;
+  b.l = 16;
+  c->kwrite(&b, k);
+  kl = b.l - 16;
+  c->vwrite(&b, v);
+  vl = b.l - kl - 16;
+  htonull(kl, b.s);
+  htonull(vl, b.s + 8);
+  if (strb_error(&b)) {
+    strb_clear(&b);
+    return -1;
+  }
+
+  fd = mkstempat(c->dirfd, tmp_path);
+  if (fd == -1) {
+    strb_clear(&b);
+    return -1;
+  }
+
+  err = strb_write(fd, &b);
+  strb_clear(&b);
+  close(fd);
+  if (err) {
+    unlinkat(c->dirfd, tmp_path, 0);
+    return -1;
+  }
+  
+  if (renameat(c->dirfd, tmp_path, c->dirfd, hexp)) {
+    unlinkat(c->dirfd, tmp_path, 0);
+    return -1;
+  }
+
+  return 0;
+}
+
+static int find_entry(disk_cache *c, const cache_key_t key,
+                      cache_key_t *_k, cache_value_t *_v) {
+  struct stat st;
+  strb b = STRB_STATIC_INIT;
+  char *ts;
+  size_t kl, vl;
+  cache_key_t k;
+  char hexp[HEXP_LEN];
+  int fd;
+
+  if (key_path(c, key, hexp)) return 0;
+
+  fd = openat(c->dirfd, hexp, O_RDONLY);
+
+  if (fd == -1) return 0;
+
+  if (fstat(fd, &st)) {
+    close(fd);
+    return 0;
+  }
+
+  if (!(st.st_mode & S_IFREG)) {
+    close(fd);
+    return 0;
+  }
+
+  strb_read(&b, fd, st.st_size);
+  close(fd);
+
+  if (strb_error(&b) || b.l < 16) {
+    strb_clear(&b);
+    return 0;
+  }
+
+  kl = ntohull(b.s);
+  vl = ntohull(b.s + 8);
+
+  if (b.l < 16 + kl + vl) {
+    strb_clear(&b);
+    return 0;
+  }
+
+  ts = b.s;
+
+  b.s += 16;
+  b.l = kl;
+
+  k = c->kread(&b);
+  if (k && c->c.keq(key, k)) {
+    if (_v) {
+      b.s += kl;
+      b.l = vl;
+      *_v = c->vread(&b);
+      if (*_v == NULL)
+        goto error;
+    }
+    if (_k)
+      *_k = k;
+    else
+      c->c.kfree(k);
+    b.s = ts;
+    strb_clear(&b);
+    return 1;
+  }
+ error:
+  c->c.kfree(k);
+  b.s = ts;
+  strb_clear(&b);
+  return 0;
+}
+
+static int disk_add(cache *_c, cache_key_t k, cache_value_t v) {
+  disk_cache *c = (disk_cache *)_c;
+
+  /* Ignore write errors */
+  write_entry(c, k, v);
+
+  return cache_add(c->mem, k, v);
+}
+
+static int disk_del(cache *_c, const cache_key_t key) {
+  disk_cache *c = (disk_cache *)_c;
+  char hexp[HEXP_LEN] = {0};
+  
+  cache_del(c->mem, key);
+
+  key_path(c, key, hexp);
+
+  return (unlinkat(c->dirfd, hexp, 0) == 0);
+}
+
+static cache_value_t disk_get(cache *_c, const cache_key_t key) {
+  disk_cache *c = (disk_cache *)_c;
+  cache_key_t k;
+  cache_value_t v;
+
+  v = cache_get(c->mem, key);
+  if (v != NULL)
+    return v;
+
+  if (find_entry(c, key, &k, &v)) {
+    if (cache_add(c->mem, k, v)) return NULL;
+    return v;
+  }
+  return NULL;
+}
+
+static void disk_destroy(cache *_c) {
+  disk_cache *c = (disk_cache *)_c;
+  cache_destroy(c->mem);
+  close(c->dirfd);
+}
+
+cache *cache_disk(const char *dirpath, cache *mem,
+                  kwrite_fn kwrite, vwrite_fn vwrite,
+                  kread_fn kread, vread_fn vread) {
+  struct stat st;
+  disk_cache *res;
+
+  mkdir(dirpath, 0777); /* This may fail, but we don't care */
+  if (lstat(dirpath, &st) != 0)
+    return NULL;
+  if (!(st.st_mode & S_IFDIR))
+    return NULL;
+
+  res = calloc(sizeof(*res), 1);
+  if (res == NULL) return NULL;
+
+  res->dirfd = open(dirpath, O_RDWR|O_CLOEXEC);
+  if (res->dirfd == -1) {
+    free(res);
+    return NULL;
+  }
+
+  res->mem = mem;
+  res->kwrite = kwrite;
+  res->vwrite = vwrite;
+  res->kread = kread;
+  res->vread = vread;
+  res->c.add = disk_add;
+  res->c.del = disk_del;
+  res->c.get = disk_get;
+  res->c.destroy = disk_destroy;
+  res->c.keq = mem->keq;
+  res->c.khash = mem->khash;
+  res->c.kfree = mem->kfree;
+  res->c.vfree = mem->vfree;
+  return (cache *)res;
+}

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -84,6 +84,7 @@ typedef struct _disk_cache {
 } disk_cache;
 
 
+/* Convert unsigned long long from network to host order */
 static unsigned long long ntohull(const char *_in) {
   const unsigned char *in = (const unsigned char *)_in;
   return ((unsigned long long)in[0] << 56 | (unsigned long long)in[1] << 48 |
@@ -92,6 +93,7 @@ static unsigned long long ntohull(const char *_in) {
           (unsigned long long)in[6] << 8 | (unsigned long long)in[7]);
 }
 
+/* Convert unsigned long long from host to network order */
 static void htonull(unsigned long long in, char *out) {
   out[0] = (unsigned char)(in >> 56);
   out[1] = (unsigned char)(in >> 48);
@@ -103,6 +105,8 @@ static void htonull(unsigned long long in, char *out) {
   out[7] = (unsigned char)(in);
 }
 
+/* Concatenate prefix and suffix into a single path string while
+   checking for overflow */
 static int catp(char *path, const char *dirp, const char *rpath) {
   if (strlcpy(path, dirp, PATH_MAX) >= PATH_MAX) {
     errno = ENAMETOOLONG;
@@ -115,6 +119,7 @@ static int catp(char *path, const char *dirp, const char *rpath) {
   return 0;
 }
 
+/* open() for a path specifed by the concatenation of dirp and rpath */
 static int openp(const char *dirp, const char *rpath, int flags, int mode) {
   char path[PATH_MAX];
 

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -63,7 +63,7 @@ static int gettimeofday(struct timeval *tp, struct timezone *tzp) {
 #include <sys/stat.h>
 
 #define O_BINARY 0
-#define setmode(a, b)
+#define _setmode(a, b)
 
 #endif
 
@@ -84,7 +84,8 @@ typedef struct _disk_cache {
 } disk_cache;
 
 
-static unsigned long long ntohull(const char *in) {
+static unsigned long long ntohull(const char *_in) {
+  const unsigned char *in = (const unsigned char *)_in;
   return ((unsigned long long)in[0] << 56 | (unsigned long long)in[1] << 48 |
           (unsigned long long)in[2] << 40 | (unsigned long long)in[3] << 32 |
           (unsigned long long)in[4] << 24 | (unsigned long long)in[5] << 16 |
@@ -92,14 +93,14 @@ static unsigned long long ntohull(const char *in) {
 }
 
 static void htonull(unsigned long long in, char *out) {
-  out[0] = (char)(in >> 56);
-  out[1] = (char)(in >> 48);
-  out[2] = (char)(in >> 40);
-  out[3] = (char)(in >> 32);
-  out[4] = (char)(in >> 24);
-  out[5] = (char)(in >> 16);
-  out[6] = (char)(in >> 8);
-  out[7] = (char)(in);
+  out[0] = (unsigned char)(in >> 56);
+  out[1] = (unsigned char)(in >> 48);
+  out[2] = (unsigned char)(in >> 40);
+  out[3] = (unsigned char)(in >> 32);
+  out[4] = (unsigned char)(in >> 24);
+  out[5] = (unsigned char)(in >> 16);
+  out[6] = (unsigned char)(in >> 8);
+  out[7] = (unsigned char)(in);
 }
 
 static int catp(char *path, const char *dirp, const char *rpath) {
@@ -134,7 +135,7 @@ static int mkstempp(const char *dirp, char *template) {
 
   /* We need to copy the result path back and set binary mode (for windows) */
   if (res != -1) {
-    setmode(res, O_BINARY);
+    _setmode(res, O_BINARY);
     memcpy(template, &path[strlen(dirp)], strlen(template));
   }
 

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -63,6 +63,7 @@ static int gettimeofday(struct timeval *tp, struct timezone *tzp) {
 #include <sys/stat.h>
 
 #define O_BINARY 0
+#define setmode(a, b)
 
 #endif
 
@@ -131,9 +132,11 @@ static int mkstempp(const char *dirp, char *template) {
 
   res = mkstemp(path);
 
-  /* We need to copy the result path back */
-  if (res != -1)
+  /* We need to copy the result path back and set binary mode (for windows) */
+  if (res != -1) {
+    setmode(res, O_BINARY);
     memcpy(template, &path[strlen(dirp)], strlen(template));
+  }
 
   return res;
 }

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_WARNINGS
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -11,7 +12,10 @@
 #include <Windows.h>
 
 #include <process.h>
+#include <direct.h>
 #include <io.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 struct timezone;
 
@@ -43,13 +47,22 @@ static int gettimeofday(struct timeval *tp, struct timezone *tzp) {
   return 0;
 }
 
+#define open _open
+#define unlink _unlink
+#define mkdir(p, f) _mkdir(p)
+#define close _close
+#define strdup _strdup
+#define lstat _stat64
+#define fstat _fstat64
+#define stat __stat64
+
 #else
 #define PATH_MAX 1024
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/stat.h>
 #endif
 
-#include <sys/stat.h>
 
 #include "cache.h"
 #include "util/skein.h"

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -61,6 +61,9 @@ static int gettimeofday(struct timeval *tp, struct timezone *tzp) {
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/stat.h>
+
+#define O_BINARY 0
+
 #endif
 
 
@@ -281,7 +284,7 @@ static int find_entry(disk_cache *c, const cache_key_t key,
 
   if (key_path(c, key, hexp)) return 0;
 
-  fd = openp(c->dirp, hexp, O_RDONLY, 0);
+  fd = openp(c->dirp, hexp, O_RDONLY|O_BINARY, 0);
 
   if (fd == -1) return 0;
 

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -129,7 +129,7 @@ static int mkstempp(const char *dirp, char *template) {
   res = mkstemp(path);
 
   /* We need to copy the result path back */
-  if (res == 0)
+  if (res != -1)
     memcpy(template, &path[strlen(dirp)], strlen(template));
 
   return res;

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -337,7 +337,8 @@ static int find_entry(disk_cache *c, const cache_key_t key,
     return 1;
   }
  error:
-  c->c.kfree(k);
+  if (k)
+    c->c.kfree(k);
   b.s = ts;
   strb_clear(&b);
   return 0;

--- a/src/gpuarray/blas.h
+++ b/src/gpuarray/blas.h
@@ -9,8 +9,8 @@ extern "C" {
 #endif
 
 // only for vector-vector dot
-GPUARRAY_PUBLIC int GpuArray_rdot( GpuArray *X, GpuArray *Y,
-                                   GpuArray *Z, int nocopy);
+GPUARRAY_PUBLIC int GpuArray_rdot(GpuArray *X, GpuArray *Y,
+                                  GpuArray *Z, int nocopy);
 #define GpuArray_hdot GpuArray_rdot
 #define GpuArray_sdot GpuArray_rdot
 #define GpuArray_ddot GpuArray_rdot

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -494,22 +494,9 @@ GPUARRAY_PUBLIC int gpukernel_call(gpukernel *k, unsigned int n,
                                    size_t shared, void **args);
 
 /**
- * (Deprecated) Get the kernel binary.
+ * Get the kernel binary (REMOVED).
  *
- * This function is deprecated and will be removed in the next release.
- *
- * This can be use to cache kernel binaries after compilation of a
- * specific device.  The kernel can be recreated by calling
- * kernel_alloc with the binary and size and passing `GA_USE_BINARY`
- * as the use flags.
- *
- * The returned pointer is allocated and must be freed by the caller.
- *
- * \param k kernel
- * \param sz size of the returned binary
- * \param obj pointer to the binary for the kernel.
- *
- * \returns GA_NO_ERROR or an error code if an error occurred.
+ * Always returns GA_DEPRECATED_ERROR.
  */
 GPUARRAY_PUBLIC int gpukernel_binary(gpukernel *k, size_t *sz, void **obj);
 

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -328,9 +328,9 @@ GPUARRAY_PUBLIC int gpudata_move(gpudata *dst, size_t dstoff,
  * \returns the new buffer in dst_ctx or NULL if no efficient way to
  *          transfer could be found.
  */
-GPUARRAY_LOCAL int gpudata_transfer(gpudata *dst, size_t dstoff,
-                                    gpudata *src, size_t srcoff,
-                                    size_t sz);
+GPUARRAY_PUBLIC int gpudata_transfer(gpudata *dst, size_t dstoff,
+                                     gpudata *src, size_t srcoff,
+                                     size_t sz);
 
 /**
  * Transfer data from a buffer to memory.

--- a/src/gpuarray/buffer.h
+++ b/src/gpuarray/buffer.h
@@ -494,9 +494,22 @@ GPUARRAY_PUBLIC int gpukernel_call(gpukernel *k, unsigned int n,
                                    size_t shared, void **args);
 
 /**
- * Get the kernel binary (REMOVED).
+ * (Deprecated) Get the kernel binary.
  *
- * Always returns GA_DEPRECATED_ERROR.
+ * This function is deprecated and will be removed in the next release.
+ *
+ * This can be use to cache kernel binaries after compilation of a
+ * specific device.  The kernel can be recreated by calling
+ * kernel_alloc with the binary and size and passing `GA_USE_BINARY`
+ * as the use flags.
+ *
+ * The returned pointer is allocated and must be freed by the caller.
+ *
+ * \param k kernel
+ * \param sz size of the returned binary
+ * \param obj pointer to the binary for the kernel.
+ *
+ * \returns GA_NO_ERROR or an error code if an error occurred.
  */
 GPUARRAY_PUBLIC int gpukernel_binary(gpukernel *k, size_t *sz, void **obj);
 

--- a/src/gpuarray/config.h
+++ b/src/gpuarray/config.h
@@ -12,19 +12,15 @@
   #else
    #define GPUARRAY_PUBLIC __declspec(dllimport)
   #endif
-  #define GPUARRAY_LOCAL
  #else
   #if __GNUC__ >= 4
    #define GPUARRAY_PUBLIC __attribute__((visibility ("default")))
-   #define GPUARRAY_LOCAL  __attribute__((visibility ("hidden")))
   #else
-   #define GPUARRAY_PUBLIC
-   #define GPUARRAY_LOCAL
+   #error "Don't know how to export symbols on this platform"
   #endif
  #endif
 #else
  #define GPUARRAY_PUBLIC
- #define GPUARRAY_LOCAL
 #endif
 
 #ifdef _MSC_VER

--- a/src/gpuarray/error.h
+++ b/src/gpuarray/error.h
@@ -36,6 +36,7 @@ enum ga_error {
   GA_COMM_ERROR,
   GA_XLARGE_ERROR,
   GA_LOAD_ERROR,
+  GA_DEPRECATED_ERROR,
   /* Add more error types if needed, but at the end */
   /* Don't forget to sync with Gpu_error() */
 };

--- a/src/gpuarray/error.h
+++ b/src/gpuarray/error.h
@@ -36,7 +36,6 @@ enum ga_error {
   GA_COMM_ERROR,
   GA_XLARGE_ERROR,
   GA_LOAD_ERROR,
-  GA_DEPRECATED_ERROR,
   /* Add more error types if needed, but at the end */
   /* Don't forget to sync with Gpu_error() */
 };

--- a/src/gpuarray/kernel.h
+++ b/src/gpuarray/kernel.h
@@ -107,6 +107,7 @@ GPUARRAY_PUBLIC int GpuKernel_call(GpuKernel *k, unsigned int n,
                                    const size_t *gs, const size_t *ls,
                                    size_t shared, void **args);
 
+/* Deprecated and to be removed */
 GPUARRAY_PUBLIC int GpuKernel_binary(const GpuKernel *k, size_t *sz,
                                     void **obj);
 

--- a/src/gpuarray/kernel.h
+++ b/src/gpuarray/kernel.h
@@ -107,7 +107,6 @@ GPUARRAY_PUBLIC int GpuKernel_call(GpuKernel *k, unsigned int n,
                                    const size_t *gs, const size_t *ls,
                                    size_t shared, void **args);
 
-/* Deprecated and to be removed */
 GPUARRAY_PUBLIC int GpuKernel_binary(const GpuKernel *k, size_t *sz,
                                     void **obj);
 

--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -83,7 +83,7 @@ static int ga_extcopy(GpuArray *dst, const GpuArray *src) {
 }
 
 /* Value below which a size_t multiplication will never overflow. */
-#define MUL_NO_OVERFLOW (1UL << (sizeof(size_t) * 4))
+#define MUL_NO_OVERFLOW (1ULL << (sizeof(size_t) * 4))
 
 void GpuArray_fix_flags(GpuArray *a) {
   /* Only keep the writable flag */
@@ -330,9 +330,9 @@ static int gen_take1_kernel(GpuKernel *k, gpucontext *ctx, char **err_str,
                             const GpuArray *ind, int addr32) {
   strb sb = STRB_STATIC_INIT;
   int *atypes;
-  size_t nargs, apos;
   char *sz, *ssz;
   unsigned int i, i2;
+  unsigned int nargs, apos;
   int flags = GA_USE_CLUDA;
   int res;
 
@@ -432,9 +432,9 @@ int GpuArray_take1(GpuArray *a, const GpuArray *v, const GpuArray *i,
 #if DEBUG
   char *errstr = NULL;
 #endif
-  size_t argp;
   GpuKernel k;
   unsigned int j;
+  unsigned int argp;
   int err, kerr = 0;
   int addr32 = 0;
 

--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -1096,6 +1096,9 @@ int GpuArray_fdump(FILE *fd, const GpuArray *a) {
     case GA_LONG:
       fprintf(fd, "%lld", (long long)*(int64_t *)p);
       break;
+    case GA_FLOAT:
+      fprintf(fd, "%f", *(float *)p);
+      break;
     case GA_SSIZE:
       fprintf(fd, "%" SPREFIX "d", *(ssize_t *)p);
       break;

--- a/src/gpuarray_array_blas.c
+++ b/src/gpuarray_array_blas.c
@@ -5,8 +5,8 @@
 #include "gpuarray/util.h"
 #include "gpuarray/error.h"
 
-int GpuArray_rdot( GpuArray *X, GpuArray *Y,
-        GpuArray *Z, int nocopy) {
+int GpuArray_rdot(GpuArray *X, GpuArray *Y,
+                  GpuArray *Z, int nocopy) {
     GpuArray *Xp = X;
     GpuArray copyX;
     GpuArray *Yp = Y;

--- a/src/gpuarray_blas_cuda_cublas.c
+++ b/src/gpuarray_blas_cuda_cublas.c
@@ -1640,7 +1640,7 @@ static int dgerBatch(cb_order order, size_t M, size_t N, double alpha,
   return GA_NO_ERROR;
 }
 
-GPUARRAY_LOCAL gpuarray_blas_ops cublas_ops = {
+gpuarray_blas_ops cublas_ops = {
   setup,
   teardown,
   error,

--- a/src/gpuarray_blas_opencl_clblas.c
+++ b/src/gpuarray_blas_opencl_clblas.c
@@ -491,7 +491,7 @@ static int dger(cb_order order, size_t M, size_t N, double alpha,
   return GA_NO_ERROR;
 }
 
-GPUARRAY_LOCAL gpuarray_blas_ops clblas_ops = {
+gpuarray_blas_ops clblas_ops = {
   setup,
   teardown,
   error,

--- a/src/gpuarray_blas_opencl_clblas.c
+++ b/src/gpuarray_blas_opencl_clblas.c
@@ -100,7 +100,7 @@ static int sgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
     ARRAY_INIT(C[i]);
     err = clblasSgemm(convO(order), convT(transA), convT(transB), M, N, K,
                       alpha, A[i]->buf, offA[i], lda, B[i]->buf, offB[i], ldb,
-                      beta, C[i]->buf, offB[i], ldc, 1, &ctx->q,
+                      beta, C[i]->buf, offC[i], ldc, 1, &ctx->q,
                       num_ev, num_ev == 0 ? NULL : evl, &ev);
     if (err != clblasSuccess)
       return GA_BLAS_ERROR;
@@ -132,7 +132,7 @@ static int dgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
     ARRAY_INIT(C[i]);
     err = clblasDgemm(convO(order), convT(transA), convT(transB), M, N, K,
                       alpha, A[i]->buf, offA[i], lda, B[i]->buf, offB[i], ldb,
-                      beta, C[i]->buf, offB[i], ldc, 1, &ctx->q,
+                      beta, C[i]->buf, offC[i], ldc, 1, &ctx->q,
                       num_ev, num_ev == 0 ? NULL : evl, &ev);
     if (err != clblasSuccess)
       return GA_BLAS_ERROR;

--- a/src/gpuarray_blas_opencl_clblast.c
+++ b/src/gpuarray_blas_opencl_clblast.c
@@ -525,7 +525,7 @@ static int dger(cb_order order, size_t M, size_t N, double alpha,
   return GA_NO_ERROR;
 }
 
-GPUARRAY_LOCAL gpuarray_blas_ops clblast_ops = {
+gpuarray_blas_ops clblast_ops = {
   setup,
   teardown,
   error,

--- a/src/gpuarray_blas_opencl_clblast.c
+++ b/src/gpuarray_blas_opencl_clblast.c
@@ -68,7 +68,7 @@ static int hgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
     ARRAY_INIT(C[i]);
     err = CLBlastHgemm(convO(order), convT(transA), convT(transB), M, N, K,
                        float_to_half(alpha), A[i]->buf, offA[i], lda, B[i]->buf, offB[i], ldb,
-                       float_to_half(beta), C[i]->buf, offB[i], ldc, &ctx->q, &ev);
+                       float_to_half(beta), C[i]->buf, offC[i], ldc, &ctx->q, &ev);
     if (err != kSuccess)
       return GA_BLAS_ERROR;
     ARRAY_FINI(A[i]);
@@ -97,7 +97,7 @@ static int sgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
     ARRAY_INIT(C[i]);
     err = CLBlastSgemm(convO(order), convT(transA), convT(transB), M, N, K,
                       alpha, A[i]->buf, offA[i], lda, B[i]->buf, offB[i], ldb,
-                      beta, C[i]->buf, offB[i], ldc, &ctx->q, &ev);
+                      beta, C[i]->buf, offC[i], ldc, &ctx->q, &ev);
     if (err != kSuccess)
       return GA_BLAS_ERROR;
     ARRAY_FINI(A[i]);
@@ -126,7 +126,7 @@ static int dgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
     ARRAY_INIT(C[i]);
     err = CLBlastDgemm(convO(order), convT(transA), convT(transB), M, N, K,
                       alpha, A[i]->buf, offA[i], lda, B[i]->buf, offB[i], ldb,
-                      beta, C[i]->buf, offB[i], ldc, &ctx->q, &ev);
+                      beta, C[i]->buf, offC[i], ldc, &ctx->q, &ev);
     if (err != kSuccess)
       return GA_BLAS_ERROR;
     ARRAY_FINI(A[i]);

--- a/src/gpuarray_buffer.c
+++ b/src/gpuarray_buffer.c
@@ -187,7 +187,7 @@ int gpukernel_call(gpukernel *k, unsigned int n, const size_t *gs,
 }
 
 int gpukernel_binary(gpukernel *k, size_t *sz, void **obj) {
-  return ((partial_gpukernel *)k)->ctx->ops->kernel_binary(k, sz, obj);
+  return GA_DEPRECATED_ERROR;
 }
 
 int gpukernel_property(gpukernel *k, int prop_id, void *res) {

--- a/src/gpuarray_buffer.c
+++ b/src/gpuarray_buffer.c
@@ -45,10 +45,10 @@ gpucontext *gpucontext_init(const char *name, int dev, int flags, int *ret) {
   if (res == NULL)
     return NULL;
   res->ops = ops;
-  if (gpucontext_property(res, GA_CTX_PROP_BLAS_OPS, &res->blas_ops) != GA_NO_ERROR)
+  if (gpucontext_property(res, GA_CTX_PROP_BLAS_OPS, (void *)&res->blas_ops) != GA_NO_ERROR)
     res->blas_ops = NULL;
   res->blas_handle = NULL;
-  if (gpucontext_property(res, GA_CTX_PROP_COMM_OPS, &res->comm_ops) != GA_NO_ERROR)
+  if (gpucontext_property(res, GA_CTX_PROP_COMM_OPS, (void *)&res->comm_ops) != GA_NO_ERROR)
     res->comm_ops = NULL;
   res->extcopy_cache = NULL;
   return res;

--- a/src/gpuarray_buffer.c
+++ b/src/gpuarray_buffer.c
@@ -187,7 +187,7 @@ int gpukernel_call(gpukernel *k, unsigned int n, const size_t *gs,
 }
 
 int gpukernel_binary(gpukernel *k, size_t *sz, void **obj) {
-  return GA_DEPRECATED_ERROR;
+  return ((partial_gpukernel *)k)->ctx->ops->kernel_binary(k, sz, obj);
 }
 
 int gpukernel_property(gpukernel *k, int prop_id, void *res) {

--- a/src/gpuarray_buffer_blas.c
+++ b/src/gpuarray_buffer_blas.c
@@ -10,7 +10,7 @@ int gpublas_setup(gpucontext *ctx) {
 
 void gpublas_teardown(gpucontext *ctx) {
   if (ctx->blas_ops != NULL)
-    return ctx->blas_ops->teardown(ctx);
+    ctx->blas_ops->teardown(ctx);
 }
 
 const char *gpublas_error(gpucontext *ctx) {

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1034,7 +1034,7 @@ static int call_compiler(cuda_context *ctx, strb *src, strb *ptx, strb *log) {
 
   if (strb_ensure(ptx, buflen) == 0) {
     err = nvrtcGetPTX(prog, ptx->s+ptx->l);
-    if (err == NVRTC_SUCCESS) ptx->l = buflen;
+    if (err == NVRTC_SUCCESS) ptx->l += buflen;
   }
 
 end:

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1120,17 +1120,23 @@ static int compile(cuda_context *ctx, strb *src, strb* bin, strb *log) {
   err = make_bin(ctx, &ptx, bin, log);
   if (err != GA_NO_ERROR) return err;
   if (ctx->disk_cache) {
-    pk = memdup(&k, sizeof(k));
+    pk = calloc(sizeof(kernel_key), 1);
     if (pk == NULL)
       return GA_NO_ERROR;
+    memcpy(pk->bin_id, k.bin_id, 64);
+    strb_appendb(&pk->src, src);
+    if (strb_error(&pk->src)) {
+      key_free((cache_key_t)pk);
+      return GA_NO_ERROR;
+    }
     cbin = strb_alloc(bin->l);
     if (cbin == NULL) {
-      free(pk);
+      key_free((cache_key_t)pk);
       return GA_NO_ERROR;
     }
     strb_appendb(cbin, bin);
     if (strb_error(cbin)) {
-      free(pk);
+      key_free((cache_key_t)pk);
       strb_free(cbin);
       return GA_NO_ERROR;
     }

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -1025,7 +1025,7 @@ static int call_compiler(cuda_context *ctx, strb *src, strb *ptx, strb *log) {
     strb_appends(log, "NVRTC compile log::\n");
     if (strb_ensure(log, buflen) == 0)
       if (nvrtcGetProgramLog(prog, log->s+log->l) == NVRTC_SUCCESS)
-        log->l += buflen - 1;
+        log->l += buflen - 1; // Remove the final NUL
     strb_appendc(log, '\n');
   }
 

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -39,7 +39,7 @@ STATIC_ASSERT(sizeof(GpuArrayIpcMemHandle) == sizeof(CUipcMemHandle), cuda_ipcme
 
 static CUresult err;
 
-GPUARRAY_LOCAL const gpuarray_buffer_ops cuda_ops;
+const gpuarray_buffer_ops cuda_ops;
 
 static void cuda_freekernel(gpukernel *);
 static int cuda_property(gpucontext *, gpudata *, gpukernel *, int, void *);
@@ -1689,7 +1689,6 @@ static const char *cuda_error(gpucontext *c) {
   return errstr;
 }
 
-GPUARRAY_LOCAL
 const gpuarray_buffer_ops cuda_ops = {cuda_get_platform_count,
                                       cuda_get_device_count,
                                       cuda_init,

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -1076,34 +1076,6 @@ static int cl_callkernel(gpukernel *k, unsigned int n,
   return GA_NO_ERROR;
 }
 
-static int cl_kernelbin(gpukernel *k, size_t *sz, void **obj) {
-  cl_ctx *ctx = k->ctx;
-  cl_program p;
-  size_t rsz;
-  void *res;
-
-  ASSERT_KER(k);
-  ASSERT_CTX(ctx);
-
-  ctx->err = clGetKernelInfo(k->k, CL_KERNEL_PROGRAM, sizeof(p), &p, NULL);
-  if (ctx->err != CL_SUCCESS)
-    return GA_IMPL_ERROR;
-  ctx->err = clGetProgramInfo(p, CL_PROGRAM_BINARY_SIZES, sizeof(rsz), &rsz, NULL);
-  if (ctx->err != CL_SUCCESS)
-    return GA_IMPL_ERROR;
-  res = malloc(rsz);
-  if (res == NULL)
-    return GA_MEMORY_ERROR;
-  ctx->err = clGetProgramInfo(p, CL_PROGRAM_BINARIES, sizeof(res), &res, NULL);
-  if (ctx->err != CL_SUCCESS) {
-    free(res);
-    return GA_IMPL_ERROR;
-  }
-  *sz = rsz;
-  *obj = res;
-  return GA_NO_ERROR;
-}
-
 static int cl_sync(gpudata *b) {
   cl_ctx *ctx = (cl_ctx *)b->ctx;
 
@@ -1465,7 +1437,6 @@ const gpuarray_buffer_ops opencl_ops = {cl_get_platform_count,
                                         cl_releasekernel,
                                         cl_setkernelarg,
                                         cl_callkernel,
-                                        cl_kernelbin,
                                         cl_sync,
                                         cl_transfer,
                                         cl_property,

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -212,7 +212,7 @@ cl_command_queue cl_get_stream(gpucontext *ctx) {
 }
 
 static void cl_free_ctx(cl_ctx *ctx) {
-  gpuarray_blas_ops *blas_ops;
+  gpuarray_blas_ops *blas_ops = NULL;
 
   ASSERT_CTX(ctx);
   assert(ctx->refcnt != 0);

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -1076,6 +1076,34 @@ static int cl_callkernel(gpukernel *k, unsigned int n,
   return GA_NO_ERROR;
 }
 
+static int cl_kernelbin(gpukernel *k, size_t *sz, void **obj) {
+  cl_ctx *ctx = k->ctx;
+  cl_program p;
+  size_t rsz;
+  void *res;
+
+  ASSERT_KER(k);
+  ASSERT_CTX(ctx);
+
+  ctx->err = clGetKernelInfo(k->k, CL_KERNEL_PROGRAM, sizeof(p), &p, NULL);
+  if (ctx->err != CL_SUCCESS)
+    return GA_IMPL_ERROR;
+  ctx->err = clGetProgramInfo(p, CL_PROGRAM_BINARY_SIZES, sizeof(rsz), &rsz, NULL);
+  if (ctx->err != CL_SUCCESS)
+    return GA_IMPL_ERROR;
+  res = malloc(rsz);
+  if (res == NULL)
+    return GA_MEMORY_ERROR;
+  ctx->err = clGetProgramInfo(p, CL_PROGRAM_BINARIES, sizeof(res), &res, NULL);
+  if (ctx->err != CL_SUCCESS) {
+    free(res);
+    return GA_IMPL_ERROR;
+  }
+  *sz = rsz;
+  *obj = res;
+  return GA_NO_ERROR;
+}
+
 static int cl_sync(gpudata *b) {
   cl_ctx *ctx = (cl_ctx *)b->ctx;
 
@@ -1437,6 +1465,7 @@ const gpuarray_buffer_ops opencl_ops = {cl_get_platform_count,
                                         cl_releasekernel,
                                         cl_setkernelarg,
                                         cl_callkernel,
+                                        cl_kernelbin,
                                         cl_sync,
                                         cl_transfer,
                                         cl_property,

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -28,7 +28,7 @@ static cl_int err;
 #define CHKFAIL(v) if (err != CL_SUCCESS) FAIL(v, GA_IMPL_ERROR)
 
 
-GPUARRAY_LOCAL const gpuarray_buffer_ops opencl_ops;
+const gpuarray_buffer_ops opencl_ops;
 
 static int cl_property(gpucontext *c, gpudata *b, gpukernel *k, int p, void *r);
 static gpudata *cl_alloc(gpucontext *c, size_t size, void *data, int flags,
@@ -1448,7 +1448,6 @@ static const char *cl_error(gpucontext *c) {
   }
 }
 
-GPUARRAY_LOCAL
 const gpuarray_buffer_ops opencl_ops = {cl_get_platform_count,
                                         cl_get_device_count,
                                         cl_init,

--- a/src/gpuarray_collectives_cuda_nccl.c
+++ b/src/gpuarray_collectives_cuda_nccl.c
@@ -455,6 +455,6 @@ static int all_gather(gpudata* src, size_t offsrc, gpudata* dest,
  * linked in \ref gpuarray_buffer_cuda.c, in order to fill a /ref gpucontext's
  * comm_ops.
  */
-GPUARRAY_LOCAL gpuarray_comm_ops nccl_ops = {
+gpuarray_comm_ops nccl_ops = {
     comm_new, comm_free,  generate_clique_id, get_count, get_rank,
     reduce,   all_reduce, reduce_scatter,     broadcast, all_gather};

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -131,8 +131,8 @@ static int gen_elemwise_basic_kernel(GpuKernel *k, gpucontext *ctx,
   strb sb = STRB_STATIC_INIT;
   unsigned int i, _i, j;
   int *ktypes;
-  size_t p;
   char *size = "ga_size", *ssize = "ga_ssize";
+  unsigned int p;
   int flags = GA_USE_CLUDA;
   int res;
 

--- a/src/gpuarray_error.c
+++ b/src/gpuarray_error.c
@@ -25,6 +25,7 @@ const char *gpuarray_error_str(int err) {
   case GA_COMM_ERROR:        return "Error in collectives call";
   case GA_XLARGE_ERROR:      return "Input size too large for operation";
   case GA_LOAD_ERROR:        return "Error loading library";
+  case GA_DEPRECATED_ERROR:  return "Deprecated (removed) functionality";
   default: return "Unknown GA error";
   }
 }

--- a/src/gpuarray_error.c
+++ b/src/gpuarray_error.c
@@ -25,7 +25,6 @@ const char *gpuarray_error_str(int err) {
   case GA_COMM_ERROR:        return "Error in collectives call";
   case GA_XLARGE_ERROR:      return "Input size too large for operation";
   case GA_LOAD_ERROR:        return "Error loading library";
-  case GA_DEPRECATED_ERROR:  return "Deprecated (removed) functionality";
   default: return "Unknown GA error";
   }
 }

--- a/src/gpuarray_mkstemp.c
+++ b/src/gpuarray_mkstemp.c
@@ -8,6 +8,8 @@
 #include <io.h>
 #define open _open
 #define mktemp _mktemp
+#else
+#define O_BINARY 0
 #endif
 
 int mkstemp(char *path) {
@@ -18,7 +20,7 @@ int mkstemp(char *path) {
     do {
         tmp = mktemp(path);
         if (tmp == NULL) return -1;
-        res = open(path, O_CREAT|O_EXCL|O_RDWR, S_IREAD|S_IWRITE);
+        res = open(path, O_CREAT|O_EXCL|O_RDWR|O_BINARY, S_IREAD|S_IWRITE);
         if (res != -1 || errno != EEXIST)
             return res;
     } while (--tries);

--- a/src/gpuarray_reduction.c
+++ b/src/gpuarray_reduction.c
@@ -644,7 +644,7 @@ static int   maxandargmaxCompile                (maxandargmax_ctx*  ctx){
 		GA_SIZE,   /* dstArgmaxOff */
 		GA_BUFFER  /* dstArgmaxSteps */
 	};
-	const size_t ARG_TYPECODES_LEN = sizeof(ARG_TYPECODES)/sizeof(*ARG_TYPECODES);
+	const unsigned int ARG_TYPECODES_LEN = sizeof(ARG_TYPECODES)/sizeof(*ARG_TYPECODES);
 	const char*  SRCS[1];
 
 	SRCS[0] = ctx->sourceCode;

--- a/src/loaders/libcuda.fn
+++ b/src/loaders/libcuda.fn
@@ -17,6 +17,10 @@ DEF_PROC(cuCtxGetDevice, (CUdevice *device));
 DEF_PROC_V2(cuCtxPushCurrent, (CUcontext ctx));
 DEF_PROC_V2(cuCtxPopCurrent, (CUcontext *pctx));
 
+DEF_PROC(cuLinkCreate, (unsigned int numOptions, CUjit_option *options, void **optionValues, CUlinkState *stateOut));
+DEF_PROC(cuLinkAddData, (CUlinkState state, CUjitInputType type, void *data, size_t size, const char *name, unsigned int numOptions, CUjit_option *options, void **optionValues));
+DEF_PROC(cuLinkComplete, (CUlinkState state, void **cubinOut, size_t *sizeOut));
+DEF_PROC(cuLinkDestroy, (CUlinkState state));
 DEF_PROC(cuModuleLoadData, (CUmodule *module, const void *image));
 DEF_PROC(cuModuleLoadDataEx, (CUmodule *module, const void *image, unsigned int numOptions, CUjit_option *options, void **optionValues));
 DEF_PROC(cuModuleUnload, (CUmodule hmod));

--- a/src/loaders/libcuda.h
+++ b/src/loaders/libcuda.h
@@ -23,6 +23,7 @@ typedef struct CUmod_st *CUmodule;
 typedef struct CUfunc_st *CUfunction;
 typedef struct CUevent_st *CUevent;
 typedef struct CUstream_st *CUstream;
+typedef struct CUlinkState_st *CUlinkState;
 
 typedef enum CUdevice_attribute_enum CUdevice_attribute;
 typedef enum CUfunction_attribute_enum CUfunction_attribute;
@@ -30,6 +31,7 @@ typedef enum CUevent_flags_enum CUevent_flags;
 typedef enum CUctx_flags_enum CUctx_flags;
 typedef enum CUipcMem_flags_enum CUipcMem_flags;
 typedef enum CUjit_option_enum CUjit_option;
+typedef enum CUjitInputType_enum CUjitInputType;
 
 #define CU_IPC_HANDLE_SIZE 64
 
@@ -204,6 +206,15 @@ enum CUjit_option_enum {
     CU_JIT_NEW_SM3X_OPT,
     CU_JIT_FAST_COMPILE,
     CU_JIT_NUM_OPTIONS
+};
+
+enum CUjitInputType_enum {
+    CU_JIT_INPUT_CUBIN = 0,
+    CU_JIT_INPUT_PTX,
+    CU_JIT_INPUT_FATBINARY,
+    CU_JIT_INPUT_OBJECT,
+    CU_JIT_INPUT_LIBRARY,
+    CU_JIT_NUM_INPUT_TYPES
 };
 
 #endif

--- a/src/private.h
+++ b/src/private.h
@@ -256,26 +256,26 @@ static inline void *memdup(const void *p, size_t s) {
   return res;
 }
 
-GPUARRAY_LOCAL int GpuArray_is_c_contiguous(const GpuArray *a);
-GPUARRAY_LOCAL int GpuArray_is_f_contiguous(const GpuArray *a);
-GPUARRAY_LOCAL int GpuArray_is_aligned(const GpuArray *a);
+int GpuArray_is_c_contiguous(const GpuArray *a);
+int GpuArray_is_f_contiguous(const GpuArray *a);
+int GpuArray_is_aligned(const GpuArray *a);
 
-GPUARRAY_LOCAL extern const gpuarray_type scalar_types[];
-GPUARRAY_LOCAL extern const gpuarray_type vector_types[];
+extern const gpuarray_type scalar_types[];
+extern const gpuarray_type vector_types[];
 
 /*
  * This function generates the kernel code to perform indexing on var id
  * from planar index 'i' using the dimensions and strides provided.
  */
-GPUARRAY_LOCAL void gpuarray_elem_perdim(strb *sb, unsigned int nd,
-                                         const size_t *dims,
-                                         const ssize_t *str,
-                                         const char *id);
+void gpuarray_elem_perdim(strb *sb, unsigned int nd,
+                          const size_t *dims,
+                          const ssize_t *str,
+                          const char *id);
 
-GPUARRAY_LOCAL void gpukernel_source_with_line_numbers(unsigned int count,
-                                                       const char **news,
-                                                       size_t *newl,
-                                                       strb *src);
+void gpukernel_source_with_line_numbers(unsigned int count,
+                                        const char **news,
+                                        size_t *newl,
+                                        strb *src);
 
 static inline uint16_t float_to_half(float value) {
 #define ga__shift 13

--- a/src/private.h
+++ b/src/private.h
@@ -100,7 +100,6 @@ struct _gpuarray_buffer_ops {
                      const size_t *gs, const size_t *ls,
                      size_t shared, void **args);
 
-  int (*kernel_binary)(gpukernel *k, size_t *sz, void **obj);
   int (*buffer_sync)(gpudata *b);
   int (*buffer_transfer)(gpudata *dst, size_t dstoff,
                          gpudata *src, size_t srcoff, size_t sz);

--- a/src/private.h
+++ b/src/private.h
@@ -100,6 +100,7 @@ struct _gpuarray_buffer_ops {
                      const size_t *gs, const size_t *ls,
                      size_t shared, void **args);
 
+  int (*kernel_binary)(gpukernel *k, size_t *sz, void **obj);
   int (*buffer_sync)(gpudata *b);
   int (*buffer_transfer)(gpudata *dst, size_t dstoff,
                          gpudata *src, size_t srcoff, size_t sz);

--- a/src/private.h
+++ b/src/private.h
@@ -26,9 +26,9 @@ extern "C" {
 }
 #endif
 
-#define ADDR32_MAX   4294967295
-#define SADDR32_MIN -2147483648
-#define SADDR32_MAX  2147483647
+#define ADDR32_MAX   4294967295L
+#define SADDR32_MIN -2147483648L
+#define SADDR32_MAX  2147483647L
 
 struct _gpuarray_buffer_ops;
 typedef struct _gpuarray_buffer_ops gpuarray_buffer_ops;

--- a/src/private_config.h.in
+++ b/src/private_config.h.in
@@ -39,12 +39,12 @@ extern "C" {
 #define nelems(a) (sizeof(a)/sizeof(a[0]))
 
 #ifndef HAVE_MKSTEMP
-GPUARRAY_LOCAL int mkstemp(char *path);
+int mkstemp(char *path);
 #endif
 
 #ifndef HAVE_STRL
-GPUARRAY_LOCAL size_t strlcpy(char *dst, const char *src, size_t size);
-GPUARRAY_LOCAL size_t strlcat(char *dst, const char *src, size_t size);
+size_t strlcpy(char *dst, const char *src, size_t size);
+size_t strlcat(char *dst, const char *src, size_t size);
 #endif
 
 #ifdef __cplusplus

--- a/src/private_config.h.in
+++ b/src/private_config.h.in
@@ -22,9 +22,7 @@ extern "C" {
 #ifdef _MSC_VER
 /* God damn Microsoft ... */
 #define snprintf _snprintf
-#endif
-
-#ifdef _MSC_VER
+#define strdup _strdup
 /* MS VC++ 2008 does not support inline */
 #define inline __inline
 #define alloca _alloca

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -68,6 +68,7 @@ typedef struct _cuda_context {
   CUstream mem_s;
   gpudata *freeblocks;
   cache *kernel_cache;
+  cache *disk_cache;
   unsigned int enter;
   unsigned char major;
   unsigned char minor;

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -93,10 +93,10 @@ STATIC_ASSERT(sizeof(cuda_context) <= sizeof(gpucontext),
 
 #define ARCH_PREFIX "compute_"
 
-GPUARRAY_LOCAL cuda_context *cuda_make_ctx(CUcontext ctx, int flags);
-GPUARRAY_LOCAL CUstream cuda_get_stream(cuda_context *ctx);
-GPUARRAY_LOCAL void cuda_enter(cuda_context *ctx);
-GPUARRAY_LOCAL void cuda_exit(cuda_context *ctx);
+cuda_context *cuda_make_ctx(CUcontext ctx, int flags);
+CUstream cuda_get_stream(cuda_context *ctx);
+void cuda_enter(cuda_context *ctx);
+void cuda_exit(cuda_context *ctx);
 
 struct _gpudata {
   CUdeviceptr ptr;
@@ -115,11 +115,10 @@ struct _gpudata {
 #endif
 };
 
-GPUARRAY_LOCAL gpudata *cuda_make_buf(cuda_context *c, CUdeviceptr p,
-                                      size_t sz);
-GPUARRAY_LOCAL size_t cuda_get_sz(gpudata *g);
-GPUARRAY_LOCAL int cuda_wait(gpudata *, int);
-GPUARRAY_LOCAL int cuda_record(gpudata *, int);
+gpudata *cuda_make_buf(cuda_context *c, CUdeviceptr p, size_t sz);
+size_t cuda_get_sz(gpudata *g);
+int cuda_wait(gpudata *, int);
+int cuda_record(gpudata *, int);
 
 /* private flags are in the upper 16 bits */
 #define CUDA_WAIT_READ  0x10000

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -137,8 +137,6 @@ struct _gpukernel {
   CUmodule m;
   CUfunction k;
   void **args;
-  size_t bin_sz;
-  void *bin;
   int *types;
   unsigned int argcount;
   unsigned int refcnt;

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -68,7 +68,7 @@ typedef struct _cuda_context {
   CUstream mem_s;
   gpudata *freeblocks;
   cache *kernel_cache;
-  cache *disk_cache;
+  cache *disk_cache; // This is per-context to avoid lock contention
   unsigned int enter;
   unsigned char major;
   unsigned char minor;

--- a/src/private_cuda.h
+++ b/src/private_cuda.h
@@ -137,6 +137,8 @@ struct _gpukernel {
   CUmodule m;
   CUfunction k;
   void **args;
+  size_t bin_sz;
+  void *bin;
   int *types;
   unsigned int argcount;
   unsigned int refcnt;

--- a/src/private_opencl.h
+++ b/src/private_opencl.h
@@ -67,9 +67,9 @@ struct _gpukernel {
 #endif
 };
 
-GPUARRAY_LOCAL cl_ctx *cl_make_ctx(cl_context ctx, int flags);
-GPUARRAY_LOCAL cl_command_queue cl_get_stream(gpucontext *ctx);
-GPUARRAY_LOCAL gpudata *cl_make_buf(gpucontext *c, cl_mem buf);
-GPUARRAY_LOCAL cl_mem cl_get_buf(gpudata *g);
+cl_ctx *cl_make_ctx(cl_context ctx, int flags);
+cl_command_queue cl_get_stream(gpucontext *ctx);
+gpudata *cl_make_buf(gpucontext *c, cl_mem buf);
+cl_mem cl_get_buf(gpudata *g);
 
 #endif

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,4 +2,5 @@ set_rel(UTIL_SRC
 strb.c
 xxhash.c
 integerfactoring.c
+skein.c
 )

--- a/src/util/skein.c
+++ b/src/util/skein.c
@@ -307,3 +307,11 @@ int Skein_512_Final(Skein_512_Ctxt_t *ctx, u08b_t *hashVal) {
   }
   return SKEIN_SUCCESS;
 }
+
+int Skein_512(const u08b_t *msg, size_t msgByteCnt, u08b_t *hashVal) {
+  Skein_512_Ctxt_t ctx;
+  if (Skein_512_Init(&ctx)) return SKEIN_FAIL;
+  if (Skein_512_Update(&ctx, msg, msgByteCnt)) return SKEIN_FAIL;
+  if (Skein_512_Final(&ctx, hashVal)) return SKEIN_FAIL;
+  return SKEIN_SUCCESS;
+}

--- a/src/util/skein.c
+++ b/src/util/skein.c
@@ -1,0 +1,309 @@
+/***********************************************************************
+**
+** Implementation of the Skein hash function.
+**
+** Source code author: Doug Whiting, 2008.
+**
+** This algorithm and source code is released to the public domain.
+**
+************************************************************************/
+
+#include <string.h>      /* get the memcpy/memset functions */
+#include "skein.h"       /* get the Skein API definitions   */
+
+#define MK_64 SKEIN_MK_64
+
+/* blkSize =  512 bits. hashSize =  512 bits */
+static const u64b_t SKEIN_512_IV_512[] =
+  {
+    MK_64(0x4903ADFF,0x749C51CE),
+    MK_64(0x0D95DE39,0x9746DF03),
+    MK_64(0x8FD19341,0x27C79BCE),
+    MK_64(0x9A255629,0xFF352CB1),
+    MK_64(0x5DB62599,0xDF6CA7B0),
+    MK_64(0xEABE394C,0xA9D5C3F4),
+    MK_64(0x991112C7,0x1A75B523),
+    MK_64(0xAE18A40B,0x660FCC33)
+  };
+
+static void Skein_Put64_LSB_First(u08b_t *dst,const u64b_t *src,size_t bCnt) {
+  size_t n;
+
+  for (n = 0; n < bCnt; n++)
+    dst[n] = (u08b_t)(src[n>>3] >> (8*(n&7)));
+}
+
+static void Skein_Get64_LSB_First(u64b_t *dst, const u08b_t *src,
+                                  size_t wCnt) {
+  size_t n;
+
+  for (n=0; n<8*wCnt; n+=8)
+    dst[n/8] = (((u64b_t) src[n  ])) +
+      (((u64b_t) src[n+1]) <<  8) +
+      (((u64b_t) src[n+2]) << 16) +
+      (((u64b_t) src[n+3]) << 24) +
+      (((u64b_t) src[n+4]) << 32) +
+      (((u64b_t) src[n+5]) << 40) +
+      (((u64b_t) src[n+6]) << 48) +
+      (((u64b_t) src[n+7]) << 56) ;
+}
+
+static u64b_t Skein_Swap64(u64b_t in) {
+  u64b_t o;
+  u08b_t *out = (u08b_t *)&o;
+  out[7] = in >> 56;
+  out[6] = in >> 48;
+  out[5] = in >> 40;
+  out[4] = in >> 32;
+  out[3] = in >> 24;
+  out[2] = in >> 16;
+  out[1] = in >> 8;
+  out[0] = in;
+  return o;
+}
+
+/*****************************************************************/
+/* Function to process blkCnt (nonzero) full block(s) of data. */
+#define BLK_BITS        (WCNT*64)               /* some useful definitions for \
+                                                   code here */
+#define KW_TWK_BASE     (0)
+#define KW_KEY_BASE     (3)
+#define ks              (kw + KW_KEY_BASE)
+#define ts              (kw + KW_TWK_BASE)
+
+#define RotL_64(x,N)    (((x) << (N)) | ((x) >> (64-(N))))
+
+static void Skein_512_Process_Block(Skein_512_Ctxt_t *ctx, const u08b_t *blkPtr,
+                             size_t blkCnt, size_t byteCntAdd) {
+  enum {
+      WCNT = SKEIN_512_STATE_WORDS
+  };
+#define RCNT  (SKEIN_512_ROUNDS_TOTAL/8)
+
+  u64b_t  kw[WCNT+4];                         /* key schedule words : chaining vars + tweak */
+  u64b_t  X0,X1,X2,X3,X4,X5,X6,X7;            /* local copy of vars, for speed */
+  u64b_t  w [WCNT];                           /* local copy of input block */
+
+  Skein_assert(blkCnt != 0);                  /* never call with blkCnt == 0! */
+  ts[0] = ctx->h.T[0];
+  ts[1] = ctx->h.T[1];
+  do  {
+        /* this implementation only supports 2**64 input bytes (no carry out here) */
+    ts[0] += byteCntAdd;                    /* update processed length */
+
+    /* precompute the key schedule for this block */
+    ks[0] = ctx->X[0];
+    ks[1] = ctx->X[1];
+    ks[2] = ctx->X[2];
+    ks[3] = ctx->X[3];
+    ks[4] = ctx->X[4];
+    ks[5] = ctx->X[5];
+    ks[6] = ctx->X[6];
+    ks[7] = ctx->X[7];
+    ks[8] = ks[0] ^ ks[1] ^ ks[2] ^ ks[3] ^
+      ks[4] ^ ks[5] ^ ks[6] ^ ks[7] ^ SKEIN_KS_PARITY;
+
+    ts[2] = ts[0] ^ ts[1];
+
+    Skein_Get64_LSB_First(w,blkPtr,WCNT); /* get input block in little-endian format */
+
+    X0   = w[0] + ks[0];                    /* do the first full key injection */
+    X1   = w[1] + ks[1];
+    X2   = w[2] + ks[2];
+    X3   = w[3] + ks[3];
+    X4   = w[4] + ks[4];
+    X5   = w[5] + ks[5] + ts[0];
+    X6   = w[6] + ks[6] + ts[1];
+    X7   = w[7] + ks[7];
+
+    blkPtr += SKEIN_512_BLOCK_BYTES;
+
+    /* run the rounds */
+#define Round512(p0,p1,p2,p3,p4,p5,p6,p7,ROT,rNum)                  \
+    X##p0 += X##p1; X##p1 = RotL_64(X##p1,ROT##_0); X##p1 ^= X##p0; \
+    X##p2 += X##p3; X##p3 = RotL_64(X##p3,ROT##_1); X##p3 ^= X##p2; \
+    X##p4 += X##p5; X##p5 = RotL_64(X##p5,ROT##_2); X##p5 ^= X##p4; \
+    X##p6 += X##p7; X##p7 = RotL_64(X##p7,ROT##_3); X##p7 ^= X##p6; \
+
+#define R512(p0,p1,p2,p3,p4,p5,p6,p7,ROT,rNum)      /* unrolled */  \
+    Round512(p0,p1,p2,p3,p4,p5,p6,p7,ROT,rNum)
+
+#define I512(R)                                                     \
+    X0   += ks[((R)+1) % 9];   /* inject the key schedule value */  \
+    X1   += ks[((R)+2) % 9];                                        \
+    X2   += ks[((R)+3) % 9];                                        \
+    X3   += ks[((R)+4) % 9];                                        \
+    X4   += ks[((R)+5) % 9];                                        \
+    X5   += ks[((R)+6) % 9] + ts[((R)+1) % 3];                      \
+    X6   += ks[((R)+7) % 9] + ts[((R)+2) % 3];                      \
+    X7   += ks[((R)+8) % 9] +     (R)+1;
+
+    {
+
+#define R512_8_rounds(R)  /* do 8 full rounds */  \
+        R512(0,1,2,3,4,5,6,7,R_512_0,8*(R)+ 1);   \
+        R512(2,1,4,7,6,5,0,3,R_512_1,8*(R)+ 2);   \
+        R512(4,1,6,3,0,5,2,7,R_512_2,8*(R)+ 3);   \
+        R512(6,1,0,7,2,5,4,3,R_512_3,8*(R)+ 4);   \
+        I512(2*(R));                              \
+        R512(0,1,2,3,4,5,6,7,R_512_4,8*(R)+ 5);   \
+        R512(2,1,4,7,6,5,0,3,R_512_5,8*(R)+ 6);   \
+        R512(4,1,6,3,0,5,2,7,R_512_6,8*(R)+ 7);   \
+        R512(6,1,0,7,2,5,4,3,R_512_7,8*(R)+ 8);   \
+        I512(2*(R)+1);        /* and key injection */
+
+      R512_8_rounds( 0);
+
+#define R512_Unroll_R(NN) (SKEIN_512_ROUNDS_TOTAL/8 > (NN))
+
+  #if   R512_Unroll_R( 1)
+      R512_8_rounds( 1);
+  #endif
+  #if   R512_Unroll_R( 2)
+      R512_8_rounds( 2);
+  #endif
+  #if   R512_Unroll_R( 3)
+      R512_8_rounds( 3);
+  #endif
+  #if   R512_Unroll_R( 4)
+      R512_8_rounds( 4);
+  #endif
+  #if   R512_Unroll_R( 5)
+      R512_8_rounds( 5);
+  #endif
+  #if   R512_Unroll_R( 6)
+      R512_8_rounds( 6);
+  #endif
+  #if   R512_Unroll_R( 7)
+      R512_8_rounds( 7);
+  #endif
+  #if   R512_Unroll_R( 8)
+      R512_8_rounds( 8);
+  #endif
+  #if   R512_Unroll_R( 9)
+      R512_8_rounds( 9);
+  #endif
+  #if   R512_Unroll_R(10)
+      R512_8_rounds(10);
+  #endif
+  #if   R512_Unroll_R(11)
+      R512_8_rounds(11);
+  #endif
+  #if   R512_Unroll_R(12)
+      R512_8_rounds(12);
+  #endif
+  #if   R512_Unroll_R(13)
+      R512_8_rounds(13);
+  #endif
+  #if   R512_Unroll_R(14)
+      R512_8_rounds(14);
+  #endif
+    }
+
+    /* do the final "feedforward" xor, update context chaining vars */
+    ctx->X[0] = X0 ^ w[0];
+    ctx->X[1] = X1 ^ w[1];
+    ctx->X[2] = X2 ^ w[2];
+    ctx->X[3] = X3 ^ w[3];
+    ctx->X[4] = X4 ^ w[4];
+    ctx->X[5] = X5 ^ w[5];
+    ctx->X[6] = X6 ^ w[6];
+    ctx->X[7] = X7 ^ w[7];
+
+    ts[1] &= ~SKEIN_T1_FLAG_FIRST;
+  }
+  while (--blkCnt);
+  ctx->h.T[0] = ts[0];
+  ctx->h.T[1] = ts[1];
+}
+
+/*****************************************************************/
+/*     512-bit Skein                                             */
+/*****************************************************************/
+
+/*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
+/* init the context for a straight hashing operation  */
+int Skein_512_Init(Skein_512_Ctxt_t *ctx) {
+  ctx->h.hashBitLen = 512;         /* output hash bit count */
+  memcpy(ctx->X,SKEIN_512_IV_512,sizeof(ctx->X));
+
+  /* Set up to process the data message portion of the hash (default) */
+  Skein_Start_New_Type(ctx,MSG);              /* T0=0, T1= MSG type */
+
+  return SKEIN_SUCCESS;
+}
+
+/*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
+/* process the input bytes */
+int Skein_512_Update(Skein_512_Ctxt_t *ctx, const u08b_t *msg,
+                     size_t msgByteCnt) {
+  size_t n;
+
+  Skein_Assert(ctx->h.bCnt <= SKEIN_512_BLOCK_BYTES,SKEIN_FAIL);    /* catch uninitialized context */
+
+  /* process full blocks, if any */
+  if (msgByteCnt + ctx->h.bCnt > SKEIN_512_BLOCK_BYTES) {
+    if (ctx->h.bCnt) {                              /* finish up any buffered message data */
+      n = SKEIN_512_BLOCK_BYTES - ctx->h.bCnt;  /* # bytes free in buffer b[] */
+      if (n) {
+        Skein_assert(n < msgByteCnt);         /* check on our logic here */
+        memcpy(&ctx->b[ctx->h.bCnt],msg,n);
+        msgByteCnt  -= n;
+        msg         += n;
+        ctx->h.bCnt += n;
+      }
+      Skein_assert(ctx->h.bCnt == SKEIN_512_BLOCK_BYTES);
+      Skein_512_Process_Block(ctx,ctx->b,1,SKEIN_512_BLOCK_BYTES);
+      ctx->h.bCnt = 0;
+    }
+    /* now process any remaining full blocks, directly from input message data */
+    if (msgByteCnt > SKEIN_512_BLOCK_BYTES) {
+      n = (msgByteCnt-1) / SKEIN_512_BLOCK_BYTES;   /* number of full blocks to process */
+      Skein_512_Process_Block(ctx,msg,n,SKEIN_512_BLOCK_BYTES);
+      msgByteCnt -= n * SKEIN_512_BLOCK_BYTES;
+      msg        += n * SKEIN_512_BLOCK_BYTES;
+    }
+    Skein_assert(ctx->h.bCnt == 0);
+  }
+
+  /* copy any remaining source message data bytes into b[] */
+  if (msgByteCnt) {
+    Skein_assert(msgByteCnt + ctx->h.bCnt <= SKEIN_512_BLOCK_BYTES);
+    memcpy(&ctx->b[ctx->h.bCnt],msg,msgByteCnt);
+    ctx->h.bCnt += msgByteCnt;
+  }
+
+  return SKEIN_SUCCESS;
+}
+
+/*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
+/* finalize the hash computation and output the result */
+int Skein_512_Final(Skein_512_Ctxt_t *ctx, u08b_t *hashVal) {
+  size_t i,n,byteCnt;
+  u64b_t X[SKEIN_512_STATE_WORDS];
+  Skein_Assert(ctx->h.bCnt <= SKEIN_512_BLOCK_BYTES,SKEIN_FAIL);    /* catch uninitialized context */
+
+  ctx->h.T[1] |= SKEIN_T1_FLAG_FINAL;                 /* tag as the final block */
+  if (ctx->h.bCnt < SKEIN_512_BLOCK_BYTES)            /* zero pad b[] if necessary */
+    memset(&ctx->b[ctx->h.bCnt],0,SKEIN_512_BLOCK_BYTES - ctx->h.bCnt);
+
+  Skein_512_Process_Block(ctx,ctx->b,1,ctx->h.bCnt);  /* process the final block */
+
+  /* now output the result */
+  byteCnt = (ctx->h.hashBitLen + 7) >> 3;             /* total number of output bytes */
+
+  /* run Threefish in "counter mode" to generate output */
+  memset(ctx->b,0,sizeof(ctx->b));  /* zero out b[], so it can hold the counter */
+  memcpy(X,ctx->X,sizeof(X));       /* keep a local copy of counter mode "key" */
+  for (i=0;i*SKEIN_512_BLOCK_BYTES < byteCnt;i++) {
+    ((u64b_t *)ctx->b)[0]= Skein_Swap64((u64b_t) i); /* build the counter block */
+    Skein_Start_New_Type(ctx,OUT_FINAL);
+    Skein_512_Process_Block(ctx,ctx->b,1,sizeof(u64b_t)); /* run "counter mode" */
+    n = byteCnt - i*SKEIN_512_BLOCK_BYTES;   /* number of output bytes left to go */
+    if (n >= SKEIN_512_BLOCK_BYTES)
+      n  = SKEIN_512_BLOCK_BYTES;
+    Skein_Put64_LSB_First(hashVal+i*SKEIN_512_BLOCK_BYTES,ctx->X,n);   /* "output" the ctr mode bytes */
+    memcpy(ctx->X,X,sizeof(X));   /* restore the counter mode key for next time */
+  }
+  return SKEIN_SUCCESS;
+}

--- a/src/util/skein.h
+++ b/src/util/skein.h
@@ -63,6 +63,7 @@ typedef struct {                     /* 512-bit Skein hash context structure */
 int  Skein_512_Init  (Skein_512_Ctxt_t *ctx);
 int  Skein_512_Update(Skein_512_Ctxt_t *ctx, const u08b_t *msg, size_t msgByteCnt);
 int  Skein_512_Final (Skein_512_Ctxt_t *ctx, u08b_t * hashVal);
+int  Skein_512(const u08b_t *msg, size_t msgByteCnt, u08b_t *hashVal);
 
 /*****************************************************************
 ** "Internal" Skein definitions

--- a/src/util/skein.h
+++ b/src/util/skein.h
@@ -1,0 +1,145 @@
+#ifndef _SKEIN_H_
+#define _SKEIN_H_     1
+/**************************************************************************
+**
+** Interface declarations and internal definitions for Skein hashing.
+**
+** Source code author: Doug Whiting, 2008.
+**
+** This algorithm and source code is released to the public domain.
+**
+***************************************************************************
+**
+** The following compile-time switches may be defined to control some
+** tradeoffs between speed, code size, error checking, and security.
+**
+** The "default" note explains what happens when the switch is not defined.
+**
+**  SKEIN_ERR_CHECK        -- how error checking is handled inside Skein
+**                            code. If not defined, most error checking
+**                            is disabled (for performance). Otherwise,
+**                            the switch value is interpreted as:
+**                                0: use assert()      to flag errors
+**                                1: return SKEIN_FAIL to flag errors
+**
+***************************************************************************/
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stddef.h>                          /* get size_t definition */
+#include <gpuarray/config.h>
+typedef unsigned int uint_t;
+typedef uint8_t  u08b_t;
+typedef uint64_t u64b_t;
+
+enum {
+  SKEIN_SUCCESS         =      0,          /* return codes from Skein calls */
+  SKEIN_FAIL            =      1
+};
+
+#define  SKEIN_MODIFIER_WORDS  ( 2)     /* number of modifier (tweak) words */
+
+#define  SKEIN_512_STATE_WORDS ( 8)
+
+#define  SKEIN_512_STATE_BYTES ( 8*SKEIN_512_STATE_WORDS)
+#define  SKEIN_512_STATE_BITS  (64*SKEIN_512_STATE_WORDS)
+#define  SKEIN_512_BLOCK_BYTES ( 8*SKEIN_512_STATE_WORDS)
+
+typedef struct {
+  size_t  hashBitLen;                        /* size of hash result, in bits */
+  size_t  bCnt;                          /* current byte count in buffer b[] */
+  u64b_t  T[SKEIN_MODIFIER_WORDS]; /* tweak words: T[0]=byte cnt, T[1]=flags */
+} Skein_Ctxt_Hdr_t;
+
+typedef struct {                     /* 512-bit Skein hash context structure */
+  Skein_Ctxt_Hdr_t h;                     /* common header context variables */
+  u64b_t  X[SKEIN_512_STATE_WORDS];                    /* chaining variables */
+  u08b_t  b[SKEIN_512_BLOCK_BYTES]; /* partial block buffer (8-byte aligned) */
+} Skein_512_Ctxt_t;
+
+/*   Skein APIs for (incremental) "straight hashing" */
+int  Skein_512_Init  (Skein_512_Ctxt_t *ctx);
+int  Skein_512_Update(Skein_512_Ctxt_t *ctx, const u08b_t *msg, size_t msgByteCnt);
+int  Skein_512_Final (Skein_512_Ctxt_t *ctx, u08b_t * hashVal);
+
+/*****************************************************************
+** "Internal" Skein definitions
+**    -- not needed for sequential hashing API, but will be
+**           helpful for other uses of Skein (e.g., tree hash mode).
+**    -- included here so that they can be shared between
+**           reference and optimized code.
+******************************************************************/
+
+/* tweak word T[1]: bit field starting positions */
+#define SKEIN_T1_BIT(BIT)       ((BIT) - 64)            /* offset 64 because it's the second word  */
+
+#define SKEIN_T1_POS_BLK_TYPE   SKEIN_T1_BIT(120)       /* bits 120..125: type field               */
+#define SKEIN_T1_POS_FIRST      SKEIN_T1_BIT(126)       /* bits 126     : first block flag         */
+#define SKEIN_T1_POS_FINAL      SKEIN_T1_BIT(127)       /* bit  127     : final block flag         */
+
+/* tweak word T[1]: flag bit definition(s) */
+#define SKEIN_T1_FLAG_FIRST     (((u64b_t)  1 ) << SKEIN_T1_POS_FIRST)
+#define SKEIN_T1_FLAG_FINAL     (((u64b_t)  1 ) << SKEIN_T1_POS_FINAL)
+
+/* tweak word T[1]: block type field */
+#define SKEIN_BLK_TYPE_MSG      (48)              /* message processing */
+#define SKEIN_BLK_TYPE_OUT      (63)                    /* output stage */
+
+#define SKEIN_T1_BLK_TYPE(T)   (((u64b_t) (SKEIN_BLK_TYPE_##T)) << SKEIN_T1_POS_BLK_TYPE)
+#define SKEIN_T1_BLK_TYPE_MSG   SKEIN_T1_BLK_TYPE(MSG) /* message processing */
+#define SKEIN_T1_BLK_TYPE_OUT   SKEIN_T1_BLK_TYPE(OUT)       /* output stage */
+
+#define SKEIN_T1_BLK_TYPE_OUT_FINAL       (SKEIN_T1_BLK_TYPE_OUT | SKEIN_T1_FLAG_FINAL)
+
+#define SKEIN_MK_64(hi32,lo32)  ((lo32) + (((u64b_t) (hi32)) << 32))
+#define SKEIN_KS_PARITY         SKEIN_MK_64(0x1BD11BDA,0xA9FC1A22)
+
+/*
+**   Skein macros for setting tweak words, etc.
+**/
+#define Skein_Set_Tweak(ctxPtr,TWK_NUM,tVal)    {(ctxPtr)->h.T[TWK_NUM] = (tVal);}
+
+#define Skein_Set_T0(ctxPtr,T0) Skein_Set_Tweak(ctxPtr,0,T0)
+#define Skein_Set_T1(ctxPtr,T1) Skein_Set_Tweak(ctxPtr,1,T1)
+
+/* set both tweak words at once */
+#define Skein_Set_T0_T1(ctxPtr,T0,T1)         \
+    {                                           \
+    Skein_Set_T0(ctxPtr,(T0));                  \
+    Skein_Set_T1(ctxPtr,(T1));                  \
+    }
+
+/* set up for starting with a new type: h.T[0]=0; h.T[1] = NEW_TYPE; h.bCnt=0; */
+#define Skein_Start_New_Type(ctxPtr,BLK_TYPE)                         \
+  { Skein_Set_T0_T1(ctxPtr,0,SKEIN_T1_FLAG_FIRST | SKEIN_T1_BLK_TYPE_##BLK_TYPE); (ctxPtr)->h.bCnt=0; }
+
+/**************************************************
+** "Internal" Skein definitions for error checking
+***************************************************/
+
+#include <assert.h>
+#define Skein_Assert(x,retCode) { if (!(x)) return retCode; } /*  caller  error */
+#define Skein_assert(x)         assert(x)                     /* internal error */
+
+/*****************************************************************
+** Skein block function constants (shared across Ref and Opt code)
+******************************************************************/
+enum {
+  /* Skein_512 round rotation constants */
+  R_512_0_0=46, R_512_0_1=36, R_512_0_2=19, R_512_0_3=37,
+  R_512_1_0=33, R_512_1_1=27, R_512_1_2=14, R_512_1_3=42,
+  R_512_2_0=17, R_512_2_1=49, R_512_2_2=36, R_512_2_3=39,
+  R_512_3_0=44, R_512_3_1= 9, R_512_3_2=54, R_512_3_3=56,
+  R_512_4_0=39, R_512_4_1=30, R_512_4_2=34, R_512_4_3=24,
+  R_512_5_0=13, R_512_5_1=50, R_512_5_2=10, R_512_5_3=17,
+  R_512_6_0=25, R_512_6_1=29, R_512_6_2=39, R_512_6_3=43,
+  R_512_7_0= 8, R_512_7_1=35, R_512_7_2=56, R_512_7_3=22,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* ifndef _SKEIN_H_ */

--- a/src/util/skein.h
+++ b/src/util/skein.h
@@ -56,7 +56,10 @@ typedef struct {
 typedef struct {                     /* 512-bit Skein hash context structure */
   Skein_Ctxt_Hdr_t h;                     /* common header context variables */
   u64b_t  X[SKEIN_512_STATE_WORDS];                    /* chaining variables */
-  u08b_t  b[SKEIN_512_BLOCK_BYTES]; /* partial block buffer (8-byte aligned) */
+  union Skein_512_Ctxt_b_u {
+    u08b_t b[SKEIN_512_BLOCK_BYTES]; /* partial block buffer (8-byte aligned) */
+    u64b_t l[SKEIN_512_BLOCK_BYTES/8];
+  } bb;
 } Skein_512_Ctxt_t;
 
 /*   Skein APIs for (incremental) "straight hashing" */

--- a/src/util/strb.c
+++ b/src/util/strb.c
@@ -66,8 +66,30 @@ void strb_read(strb *sb, int fd, size_t sz) {
   sb->l += sz;
   while (sz) {
     res = read(fd, b, sz);
-    if (res == -1 && !(errno == EAGAIN || errno == EINTR)) { strb_seterror(sb); return; }
+    if (res == -1) {
+      if (errno == EAGAIN || errno == EINTR)
+        continue;
+      strb_seterror(sb);
+      return;
+    }
     sz -= (size_t)res;
     b += (size_t)res;
   }
+}
+
+int strb_write(int fd, strb *sb) {
+  ssize_t res;
+  size_t l = sb->l;
+  char *b = sb->s;
+  while (l) {
+    res = write(fd, b, l);
+    if (res == -1) {
+      if (errno == EAGAIN || errno == EINTR)
+        continue;
+      return -1;
+    }
+    l -= (size_t)res;
+    b += (size_t)res;
+  }
+  return 0;
 }

--- a/src/util/strb.c
+++ b/src/util/strb.c
@@ -73,8 +73,8 @@ void strb_read(strb *sb, int fd, size_t sz) {
   sb->l += sz;
   while (sz) {
     res = read(fd, b, sz);
-    if (res == -1) {
-      if (errno == EAGAIN || errno == EINTR)
+    if (res == -1 || res == 0) {
+      if (res == -1 && errno == EAGAIN || errno == EINTR)
         continue;
       strb_seterror(sb);
       return;

--- a/src/util/strb.c
+++ b/src/util/strb.c
@@ -74,7 +74,7 @@ void strb_read(strb *sb, int fd, size_t sz) {
   while (sz) {
     res = read(fd, b, sz);
     if (res == -1 || res == 0) {
-      if (res == -1 && errno == EAGAIN || errno == EINTR)
+      if (res == -1 && (errno == EAGAIN || errno == EINTR))
         continue;
       strb_seterror(sb);
       return;

--- a/src/util/strb.c
+++ b/src/util/strb.c
@@ -1,6 +1,13 @@
+#define _CRT_SECURE_NO_WARNINGS
 #include <errno.h>
 #include <stdarg.h>
+#ifdef _MSC_VER
+#include <io.h>
+#define read _read
+#define write _write
+#else
 #include <unistd.h>
+#endif
 
 #include "util/strb.h"
 

--- a/src/util/strb.h
+++ b/src/util/strb.h
@@ -162,6 +162,13 @@ static inline void strb_appendb(strb *sb, strb *sb2) {
 GPUARRAY_LOCAL void strb_appendf(strb *, const char *f, ...);
 
 /*
+ * Reads from the file specified by the given file descriptor.
+ *
+ * A read error will place the strb in error mode.
+ */
+GPUARRAY_LOCAL void strb_read(strb *, int fd, size_t sz);
+
+/*
  * Returns a C string from the content of the strb.
  *
  * Returns the `s` member of the strb after ensuring that a

--- a/src/util/strb.h
+++ b/src/util/strb.h
@@ -146,7 +146,7 @@ static inline void strb_appends(strb *sb, const char *s) {
 /*
  * Appends the content of another strb.
  */
-static inline void strb_appendb(strb *sb, strb *sb2) {
+static inline void strb_appendb(strb *sb, const strb *sb2) {
   strb_appendn(sb, sb2->s, sb2->l);
 }
 

--- a/src/util/strb.h
+++ b/src/util/strb.h
@@ -169,6 +169,13 @@ GPUARRAY_LOCAL void strb_appendf(strb *, const char *f, ...);
 GPUARRAY_LOCAL void strb_read(strb *, int fd, size_t sz);
 
 /*
+ * Write the content of an strb to the specified file descriptor.
+ *
+ * Write errors will be signaled by a nonzero return value.
+ */
+GPUARRAY_LOCAL int strb_write(int fd, strb *sb);
+
+/*
  * Returns a C string from the content of the strb.
  *
  * Returns the `s` member of the strb after ensuring that a

--- a/src/util/strb.h
+++ b/src/util/strb.h
@@ -39,14 +39,14 @@ typedef struct _strb {
  *
  * Returns NULL on error.
  */
-GPUARRAY_LOCAL strb *strb_alloc(size_t s);
+strb *strb_alloc(size_t s);
 
 /*
  * Frees an strb that was dynamically allocated.
  *
  * Don't call this for stack of global declarations, see strb_clear() instead.
  */
-GPUARRAY_LOCAL void strb_free(strb *);
+void strb_free(strb *);
 
 /*
  * Return a pointer to a dynamically allocated strb with a default
@@ -96,7 +96,7 @@ static inline void strb_clear(strb *sb) {
  * This should almost never be called directly.  Use strb_ensure()
  * instead.
  */
-GPUARRAY_LOCAL int strb_grow(strb *, size_t s);
+int strb_grow(strb *, size_t s);
 
 /*
  * Make sure there is space to store at least `s` bytes of data after
@@ -159,21 +159,21 @@ static inline void strb_appendb(strb *sb, strb *sb2) {
  *
  * A format error will place the strb in error mode.
  */
-GPUARRAY_LOCAL void strb_appendf(strb *, const char *f, ...);
+void strb_appendf(strb *, const char *f, ...);
 
 /*
  * Reads from the file specified by the given file descriptor.
  *
  * A read error will place the strb in error mode.
  */
-GPUARRAY_LOCAL void strb_read(strb *, int fd, size_t sz);
+void strb_read(strb *, int fd, size_t sz);
 
 /*
  * Write the content of an strb to the specified file descriptor.
  *
  * Write errors will be signaled by a nonzero return value.
  */
-GPUARRAY_LOCAL int strb_write(int fd, strb *sb);
+int strb_write(int fd, strb *sb);
 
 /*
  * Returns a C string from the content of the strb.

--- a/src/util/strb.h
+++ b/src/util/strb.h
@@ -46,7 +46,7 @@ strb *strb_alloc(size_t s);
  *
  * Don't call this for stack of global declarations, see strb_clear() instead.
  */
-void strb_free(strb *);
+void strb_free(strb *sb);
 
 /*
  * Return a pointer to a dynamically allocated strb with a default
@@ -96,7 +96,7 @@ static inline void strb_clear(strb *sb) {
  * This should almost never be called directly.  Use strb_ensure()
  * instead.
  */
-int strb_grow(strb *, size_t s);
+int strb_grow(strb *sb, size_t s);
 
 /*
  * Make sure there is space to store at least `s` bytes of data after
@@ -159,14 +159,17 @@ static inline void strb_appendb(strb *sb, const strb *sb2) {
  *
  * A format error will place the strb in error mode.
  */
-void strb_appendf(strb *, const char *f, ...);
+void strb_appendf(strb *sb, const char *f, ...);
 
 /*
  * Reads from the file specified by the given file descriptor.
  *
+ * This will read `sz` bytes from the file descriptor.  Insufficient
+ * data is handled as a read error.
+ *
  * A read error will place the strb in error mode.
  */
-void strb_read(strb *, int fd, size_t sz);
+void strb_read(strb *sb, int fd, size_t sz);
 
 /*
  * Write the content of an strb to the specified file descriptor.

--- a/src/util/xxhash.h
+++ b/src/util/xxhash.h
@@ -75,34 +75,6 @@ typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 
 
 /*****************************
-*  Namespace Emulation
-*****************************/
-/* Motivations :
-
-If you need to include xxHash into your library,
-but wish to avoid xxHash symbols to be present on your library interface
-in an effort to avoid potential name collision if another library also includes xxHash,
-
-you can use XXH_NAMESPACE, which will automatically prefix any symbol from xxHash
-with the value of XXH_NAMESPACE (so avoid to keep it NULL, and avoid numeric values).
-
-Note that no change is required within the calling program :
-it can still call xxHash functions using their regular name.
-They will be automatically translated by this header.
-*/
-#ifdef XXH_NAMESPACE
-#  define XXH_CAT(A,B) A##B
-#  define XXH_NAME2(A,B) XXH_CAT(A,B)
-#  define XXH32 XXH_NAME2(XXH_NAMESPACE, XXH32)
-#  define XXH32_createState XXH_NAME2(XXH_NAMESPACE, XXH32_createState)
-#  define XXH32_freeState XXH_NAME2(XXH_NAMESPACE, XXH32_freeState)
-#  define XXH32_reset XXH_NAME2(XXH_NAMESPACE, XXH32_reset)
-#  define XXH32_update XXH_NAME2(XXH_NAMESPACE, XXH32_update)
-#  define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
-#endif
-
-
-/*****************************
 *  Simple Hash Functions
 *****************************/
 

--- a/src/util/xxhash.h
+++ b/src/util/xxhash.h
@@ -106,7 +106,7 @@ They will be automatically translated by this header.
 *  Simple Hash Functions
 *****************************/
 
-GPUARRAY_LOCAL unsigned int XXH32 (const void* input, size_t length, unsigned seed);
+unsigned int XXH32 (const void* input, size_t length, unsigned seed);
 
 /*
 XXH32() :
@@ -129,9 +129,9 @@ These structures allow static allocation of XXH states.
 States must then be initialized using XXH32_reset() before first use.
 */
 
-GPUARRAY_LOCAL XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, unsigned seed);
-GPUARRAY_LOCAL XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
-GPUARRAY_LOCAL unsigned int  XXH32_digest (const XXH32_state_t* statePtr);
+XXH_errorcode XXH32_reset  (XXH32_state_t* statePtr, unsigned seed);
+XXH_errorcode XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
+unsigned int  XXH32_digest (const XXH32_state_t* statePtr);
 
 /*
 These functions calculate the xxHash of an input provided in multiple smaller packets,


### PR DESCRIPTION
This add an on-disk cache for kernels which speeds up recompilation.

From my light testing it shaves off about 1 second of a 3 seconds program that compiles an elemwise kernel and runs it, which means that it should be a net gain in most situations.

The cache is disabled by default and enabled when the environment variable GPUARRAY_CACHE_PATH is set to some path.  The cache should be fine for use over NFS with multiple processes.  Entries that were writing while a system crash happens can get corrupted or lost, but the cache should recover by ignoring and replacing bad entries. There is currently no built-in pruning mechanism, but there is a python script which can act as such.  It is safe to run it while other processes are accessing the cache.

If there is a problem accessing the given cache path, the cache will be disabled.

This still needs testing on Windows and macOS to make sure it works.  Especially on windows the semantics for touching files that are opened by other processes is significantly different, which may require adjustment.

Finally DO NOT MERGE until the 0.6 release is out the door.  This can be part of an eventual 0.6.1 release when it has been properly tested.