### PR TITLE
fix GA_DECL_SHARE_PARAM for apple opencl

### DIFF
--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -316,7 +316,7 @@ static const char CL_PREAMBLE[] =
   "#define ga_ssize long\n"
   "#define load_half(p) vload_half(0, p)\n"
   "#define store_half(p, v) vstore_half_rtn(v, 0, p)\n"
-  "#define GA_DECL_SHARED_PARAM(type, name) , __local type name[]\n"
+  "#define GA_DECL_SHARED_PARAM(type, name) , __local type *name\n"
   "#define GA_DECL_SHARED_BODY(type, name)\n";
 
 /* XXX: add complex types, quad types, and longlong */


### PR DESCRIPTION
I found that GA_DECL_SHARED_PARAM makes an error in Apple OpenCL environment.
I think it seems that this issue is caused by the array declaration not decaying into pointer.
So I modified the array declaration into pointer declaration.