### PR TITLE
GpuArray are now castable into int

### DIFF
--- a/pygpu/gpuarray.pyx
+++ b/pygpu/gpuarray.pyx
@@ -1668,6 +1668,12 @@ cdef class GpuArray:
         else:
             raise ValueError('The truth value of a multi-element array is ambiguous')
 
+    def __int__(self):
+        if self.size == 1:
+            return int(numpy.asarray(self))
+        else:
+            raise ValueError('only length-1 arrays can be converted to Python scalars')
+
     def _empty_like_me(self, dtype=None, order='C'):
         """
         _empty_like_me(dtype=None, order='C')

--- a/pygpu/tests/test_gpu_ndarray.py
+++ b/pygpu/tests/test_gpu_ndarray.py
@@ -51,6 +51,13 @@ def test_bool():
     for data in [numpy.empty((0, 33)), [[1]], [[0]], [], [0], [1], 0, 1]:
         assert bool(pygpu.asarray(data, context=ctx)) == bool(numpy.asarray(data))
 
+def test_int():
+    for data in [[[2]], [[0]], [10], [-1], 0, -21]:
+        assert int(pygpu.asarray(data, context=ctx)) == int(numpy.asarray(data))
+
+    # ValueError: only length-1 arrays can be converted to Python scalars.
+    assert_raises(ValueError, int, pygpu.asarray([], context=ctx))
+    assert_raises(ValueError, int, pygpu.asarray([0, 1], context=ctx))
 
 def test_transfer():
     for shp in [(), (5,), (6, 7), (4, 8, 9), (1, 8, 9)]:


### PR DESCRIPTION
This PR allows `GpuArray` objects to be cast into `int` where appropriate.

~~This PR fixes some issues Theano scan had with the new GPU backend (see https://github.com/Theano/Theano/issues/5503).~~