### PR TITLE
Blacklist bad versions of the cuda drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,8 @@ debug: install-debugc py
 
 .PHONY: install-debugc py debug install-relc rel config
 
-Debug:
-	mkdir Debug
-
-Debug/Makefile: Debug config
+Debug/Makefile: Debug Makefile.conf
+	mkdir -p Debug
 ifndef INSTALL_PREFIX
 	(cd Debug && NUM_DEVS=${NUM_DEVS} DEV_NAMES=${DEV_NAMES} cmake .. -DCMAKE_BUILD_TYPE=Debug)
 else
@@ -34,10 +32,8 @@ endif
 install-debugc: debugc
 	(cd Debug && ${SUDO} make install)
 
-Release:
-	mkdir Release
-
-Release/Makefile: Release config
+Release/Makefile: Makefile.conf
+	mkdir -p Release
 ifndef INSTALL_PREFIX
 	(cd Release && NUM_DEVS=${NUM_DEVS} DEV_NAMES=${DEV_NAMES} cmake .. -DCMAKE_BUILD_TYPE=Release)
 else
@@ -57,5 +53,5 @@ endif
 install-relc: relc
 	(cd Release && ${SUDO} make install)
 
-py: config
+py: Makefile.conf
 	python setup.py build_ext --inplace

--- a/src/loaders/dyn_load.c
+++ b/src/loaders/dyn_load.c
@@ -37,19 +37,19 @@ float ga_lib_version(void *h, void *sym) {
   if (!dladdr(sym, &dli))
     return -1;
 
-  real_path = realpath(dli.dli_fname,NULL);
+  real_path = realpath(dli.dli_fname, NULL);
   if (real_path == NULL)
     return -1;
 
   dot1 = strrchr(real_path, '.');
-  if (dot1 == real_path) {
+  if (dot1 == NULL) {
     free(real_path);
     return -1;
   }
   dot1[0] = '\0';
 
   dot2 = strrchr(real_path, '.');
-  if (dot2 == real_path) {
+  if (dot2 == NULL) {
     free(real_path);
     return -1;
   }

--- a/src/loaders/dyn_load.c
+++ b/src/loaders/dyn_load.c
@@ -3,8 +3,10 @@
 #if defined(__unix__) || defined(__APPLE__)
 
 #include <dlfcn.h>
-#include <stddef.h>
 #include <err.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 void *ga_load_library(const char *name) {
   void *res = dlopen(name, RTLD_LAZY|RTLD_LOCAL);
@@ -24,6 +26,45 @@ void *ga_func_ptr(void *h, const char *name) {
   return res;
 }
 
+float ga_lib_version(void *h, void *sym) {
+  Dl_info dli;
+  char *real_path;
+  char *dot1;
+  char *dot2;
+  char *end;
+  float res;
+
+  if (!dladdr(sym, &dli))
+    return -1;
+
+  real_path = realpath(dli.dli_fname,NULL);
+  if (real_path == NULL)
+    return -1;
+
+  dot1 = strrchr(real_path, '.');
+  if (dot1 == real_path) {
+    free(real_path);
+    return -1;
+  }
+  dot1[0] = '\0';
+
+  dot2 = strrchr(real_path, '.');
+  if (dot2 == real_path) {
+    free(real_path);
+    return -1;
+  }
+  dot1[0] = '.';
+
+  res = strtof(dot2+1, &end);
+  if (*end != '\0') {
+    free(real_path);
+    return -1;
+  }
+
+  free(real_path);
+  return res;
+}
+
 #else
 
 /* Should be windows */
@@ -35,6 +76,41 @@ void *ga_load_library(const char *name) {
 
 void *ga_func_ptr(void *h, const char *name) {
   return (void *)GetProcAddress(h, name);
+}
+
+float ga_lib_version(void *h, void *sym) {
+  char fname[1024];
+  char *vinfo;
+  size_t vsize;
+  VS_FIXEDFILEINFO *vp;
+  unsigned int ui;
+  float res;
+
+  if (GetModuleFileName(h, fname, sizeof(fname)) == sizeof(fname))
+    return -1;
+
+  vsize = GetFileVersionInfoSize(fname, NULL);
+  if (vsize == 0)
+    return -1;
+
+  vinfo = malloc(vsize);
+  if (vinfo == NULL)
+    return -1;
+
+  if (!GetFileVersionInfo(fname, 0, vsize, vinfo)) {
+    free(vinfo);
+    return -1;
+  }
+
+  if (!VerQueryValue(vinfo, "\\", &vp, &ui)) {
+    free(vinfo);
+    return -1;
+  }
+
+  res = HIWORD(vp->dwFileVersionMS) + (LOWORD(vp->dwFileVersionMS) / 100.0);
+
+  free(vinfo);
+  return res;
 }
 
 #endif

--- a/src/loaders/dyn_load.c
+++ b/src/loaders/dyn_load.c
@@ -69,6 +69,7 @@ float ga_lib_version(void *h, void *sym) {
 
 /* Should be windows */
 #include <windows.h>
+#pragma comment(lib,"Version.lib")
 
 void *ga_load_library(const char *name) {
   return LoadLibrary(name);
@@ -107,7 +108,7 @@ float ga_lib_version(void *h, void *sym) {
     return -1;
   }
 
-  res = HIWORD(vp->dwFileVersionMS) + (LOWORD(vp->dwFileVersionMS) / 100.0);
+  res = ( ((HIWORD(vp->dwFileVersionLS) - 10) * 10000) + LOWORD(vp->dwFileVersionLS) ) / 100.0;
 
   free(vinfo);
   return res;

--- a/src/loaders/dyn_load.h
+++ b/src/loaders/dyn_load.h
@@ -3,5 +3,6 @@
 
 void *ga_load_library(const char *name);
 void *ga_func_ptr(void *h, const char *name);
+float ga_lib_version(void *h, void *sym);
 
 #endif

--- a/src/loaders/libcuda.c
+++ b/src/loaders/libcuda.c
@@ -56,6 +56,9 @@ int load_libcuda(void) {
   v = ga_lib_version(lib, cuInit);
   if (v == -1)
     fprintf(stderr, "WARNING: could not determine cuda driver version.  Some versions return bad results, make sure your version is fine\n");
+  #ifdef DEBUG
+  fprintf(stderr, "CUDA driver version detected: %.2f\n", v);
+  #endif
 
   if (v > 373.06) {
     if (getenv("GPUARRAY_FORCE_CUDA_DRIVER_LOAD") != NULL) {

--- a/src/loaders/libcuda.c
+++ b/src/loaders/libcuda.c
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <stdio.h>
 
 #include "libcuda.h"
 #include "dyn_load.h"
@@ -41,6 +41,7 @@ static int loaded = 0;
 
 int load_libcuda(void) {
   void *lib;
+  float v;
 
   if (loaded)
     return GA_NO_ERROR;
@@ -50,6 +51,15 @@ int load_libcuda(void) {
     return GA_LOAD_ERROR;
 
   #include "libcuda.fn"
+
+  v = ga_lib_version(lib, cuInit);
+  if (v == -1)
+    fprintf(stderr, "WARNING: could not determine cuda driver version.  Some versions return bad results, make sure your version is fine\n");
+
+  if (v > 373.06) {
+    fprintf(stderr, "ERROR: refusing to load cuda driver library because the version is blacklisted\n");
+    return GA_LOAD_ERROR;
+  }
 
   loaded = 1;
   return GA_NO_ERROR;

--- a/src/loaders/libcuda.c
+++ b/src/loaders/libcuda.c
@@ -56,9 +56,17 @@ int load_libcuda(void) {
   if (v == -1)
     fprintf(stderr, "WARNING: could not determine cuda driver version.  Some versions return bad results, make sure your version is fine\n");
 
-  if (v > 373.06) {
-    fprintf(stderr, "ERROR: refusing to load cuda driver library because the version is blacklisted\n");
-    return GA_LOAD_ERROR;
+  if (v > 373.06)
+    if (getenv("GPUARRAY_FORCE_CUDA_DRIVER_LOAD") != NULL) {
+      fprintf(stderr, "WARNING: loading blacklisted driver because the load was forced.\n");
+    } else {
+      fprintf(stderr, "ERROR: refusing to load cuda driver library "
+              "because the version is blacklisted.  "
+              "Versions below 373.06 are known to be ok.\n"
+              "If you want to bypass this check and force the driver load "
+              "define GPUARRAY_FORCE_CUDA_DRIVER_LOAD in your environement.\n");
+      return GA_LOAD_ERROR;
+    }
   }
 
   loaded = 1;

--- a/src/loaders/libcuda.c
+++ b/src/loaders/libcuda.c
@@ -63,7 +63,7 @@ int load_libcuda(void) {
     } else {
       fprintf(stderr, "ERROR: refusing to load cuda driver library "
               "because the version is blacklisted.  "
-              "Versions below 373.06 are known to be ok.\n"
+              "Versions 373.06 and below are known to be ok.\n"
               "If you want to bypass this check and force the driver load "
               "define GPUARRAY_FORCE_CUDA_DRIVER_LOAD in your environement.\n");
       return GA_LOAD_ERROR;

--- a/src/loaders/libcuda.c
+++ b/src/loaders/libcuda.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "libcuda.h"
 #include "dyn_load.h"
@@ -56,7 +57,7 @@ int load_libcuda(void) {
   if (v == -1)
     fprintf(stderr, "WARNING: could not determine cuda driver version.  Some versions return bad results, make sure your version is fine\n");
 
-  if (v > 373.06)
+  if (v > 373.06) {
     if (getenv("GPUARRAY_FORCE_CUDA_DRIVER_LOAD") != NULL) {
       fprintf(stderr, "WARNING: loading blacklisted driver because the load was forced.\n");
     } else {

--- a/src/loaders/libcuda.c
+++ b/src/loaders/libcuda.c
@@ -10,7 +10,7 @@
 static char libname[] = "nvcuda.dll";
 #else /* Unix */
 #ifdef __APPLE__
-static char libname[] = "CUDA.framework/CUDA";
+static char libname[] = "/Library/Frameworks/CUDA.framework/CUDA";
 #else
 static char libname[] = "libcuda.so";
 #endif
@@ -42,7 +42,9 @@ static int loaded = 0;
 
 int load_libcuda(void) {
   void *lib;
+#ifndef __APPLE__
   float v;
+#endif
 
   if (loaded)
     return GA_NO_ERROR;
@@ -53,6 +55,10 @@ int load_libcuda(void) {
 
   #include "libcuda.fn"
 
+/*
+ * The blacklisted versions of cuda are not available on mac as far as I know.
+ */
+#ifndef __APPLE__
   v = ga_lib_version(lib, cuInit);
   if (v == -1)
     fprintf(stderr, "WARNING: could not determine cuda driver version.  Some versions return bad results, make sure your version is fine\n");
@@ -72,6 +78,7 @@ int load_libcuda(void) {
       return GA_LOAD_ERROR;
     }
   }
+#endif
 
   loaded = 1;
   return GA_NO_ERROR;

--- a/src/loaders/libopencl.c
+++ b/src/loaders/libopencl.c
@@ -8,7 +8,7 @@
 static char libname[] = "OpenCL.dll";
 #else /* Unix */
 #ifdef __APPLE__
-static char libname[] = "OpenCL.framework/OpenCL";
+static char libname[] = "/System/Library/Frameworks/OpenCL.framework/OpenCL";
 #else
 static char libname[] = "libOpenCL.so";
 #endif


### PR DESCRIPTION
The cuda drivers version 375 have some problems with the JIT that lead to bad code.

Since this is basically impossible to detect otherwise, this add a way to get the actual version of the cuda driver and blacklists bad versions.  The blacklist will need to be updated once a fixed version is released.

The last known good version is 373.06 and there are no working versions above that as far as I know, which is why the current blacklist has an open range.