### PR TITLE
Include "util.h" in "array.h".

### DIFF
--- a/src/gpuarray/array.h
+++ b/src/gpuarray/array.h
@@ -6,6 +6,7 @@
  */
 
 #include <gpuarray/buffer.h>
+#include <gpuarray/util.h>
 
 #ifdef _MSC_VER
 #ifndef inline


### PR DESCRIPTION
It seems "util.h" is not automatically included when we use "array.h". I have encountered the error while trying to use `GpuArray_ITEMSIZE()`, defined in `array.h`, which uses `gpuarray_get_elsize()` defined in `util.h`.

```
/home/notoraptor/.theano/compiledir_Linux-4.4--generic-x86_64-with-debian-stretch-sid-x86_64-2.7.13-64/tmpQo9Y8T/mod.cpp: In member function ‘int {anonymous}::__struct_compiled_op_7cd93cb03039f5356757163adef008af::run()’:
/home/notoraptor/.local/include/gpuarray/array.h:197:63: error: ‘gpuarray_get_elsize’ was not declared in this scope
 #define GpuArray_ITEMSIZE(a) gpuarray_get_elsize((a)->typecode)
                                                               ^
```

This PR add the missing inclusion in `array.h`.

@abergeron 