### PR TITLE
Require only CMake 2.8 (which appears to work just fine)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8)
 
 PROJECT(libgpuarray C)
 


### PR DESCRIPTION
Less recent versions of Ubuntu (we have 14.04.3) come with CMake 2.8.  Modifying the version, everything appears to build just fine.
