### PR TITLE
Try to fix compilation errors on Windows/Python 2.7/64 bits.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib
 .*.sw[po]
 *~
 *.pyc
+*.pyd
 *.pyo
 *.egg-info
 MANIFEST

--- a/src/cache/disk.c
+++ b/src/cache/disk.c
@@ -335,7 +335,7 @@ static int find_entry(disk_cache *c, const cache_key_t key,
       b.l = vl;
       *_v = c->vread(&b);
       if (*_v == NULL)
-        goto error;
+        goto error_find_entry;
     }
     if (_k)
       *_k = k;
@@ -345,7 +345,7 @@ static int find_entry(disk_cache *c, const cache_key_t key,
     strb_clear(&b);
     return 1;
   }
- error:
+ error_find_entry:
   if (k)
     c->c.kfree(k);
   b.s = ts;

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -387,11 +387,11 @@ static int call_basic(GpuElemwise *ge, void **args, size_t n, unsigned int nd,
   }
 
   err = GpuKernel_setarg(k, p++, &n);
-  if (err != GA_NO_ERROR) goto error;
+  if (err != GA_NO_ERROR) goto error_call_basic;
 
   for (i = 0; i < nd; i++) {
     err = GpuKernel_setarg(k, p++, &dims[i]);
-    if (err != GA_NO_ERROR) goto error;
+    if (err != GA_NO_ERROR) goto error_call_basic;
   }
 
   /* l is the number of arrays to date */
@@ -400,25 +400,25 @@ static int call_basic(GpuElemwise *ge, void **args, size_t n, unsigned int nd,
     if (is_array(ge->args[j])) {
       GpuArray *v = (GpuArray *)args[j];
       err = GpuKernel_setarg(k, p++, v->data);
-      if (err != GA_NO_ERROR) goto error;
+      if (err != GA_NO_ERROR) goto error_call_basic;
       err = GpuKernel_setarg(k, p++, &v->offset);
-      if (err != GA_NO_ERROR) goto error;
+      if (err != GA_NO_ERROR) goto error_call_basic;
       for (i = 0; i < nd; i++) {
         err = GpuKernel_setarg(k, p++, &strs[l][i]);
-        if (err != GA_NO_ERROR) goto error;
+        if (err != GA_NO_ERROR) goto error_call_basic;
       }
       l++;
     } else {
       err = GpuKernel_setarg(k, p++, args[j]);
-      if (err != GA_NO_ERROR) goto error;
+      if (err != GA_NO_ERROR) goto error_call_basic;
     }
   }
 
   err = GpuKernel_sched(k, n, &gs, &ls);
-  if (err != GA_NO_ERROR) goto error;
+  if (err != GA_NO_ERROR) goto error_call_basic;
 
   err = GpuKernel_call(k, 1, &gs, &ls, 0, NULL);
- error:
+ error_call_basic:
   return err;
 }
 

--- a/src/loaders/dyn_load.c
+++ b/src/loaders/dyn_load.c
@@ -28,7 +28,7 @@ void *ga_func_ptr(void *h, const char *name, error *e) {
 /* Should be windows */
 #include <windows.h>
 
-static inline void error_win(error *e) {
+static inline void error_win(const char* name, error *e) {
   char msgbuf[512];
   DWORD err = GetLastError();
   DWORD len = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM|
@@ -43,14 +43,14 @@ static inline void error_win(error *e) {
 void *ga_load_library(const char *name, error *e) {
   void *res = LoadLibrary(name);
   if (res == NULL)
-    error_win(e);
+    error_win(name, e);
   return res;
 }
 
 void *ga_func_ptr(void *h, const char *name, error *e) {
   void *res = (void *)GetProcAddress(h, name);
   if (res == NULL)
-    error_win(e);
+    error_win(name, e);
   return res;
 }
 

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -5,7 +5,7 @@
 #include "private_config.h"
 #include "util/error.h"
 
-static error _global_err = {};
+static error _global_err = {{0}, 0};
 error *global_err = &_global_err;
 
 int error_alloc(error **_e) {

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -6,6 +6,13 @@
 
 #include <gpuarray/error.h>
 
+/* MSVC 2008 does not support "inline". */
+#ifdef _MSC_VER
+#ifndef inline
+#define inline __inline
+#endif
+#endif
+
 /* 1024 - 4 for the int that goes after */
 #define ERROR_MSGBUF_LEN 1020
 


### PR DESCRIPTION
The last master version of libgpuarray fails to compile on Windows 8.1 64 bits for Python 2.7 with Microsoft C++ Compiler 2008. This PR tries to fix all errors I have found. **Not yet tested on Linux**.

@abergeron @nouiz 