### PR TITLE
Fix sphinx warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ distribute*tar.gz
 *.so
 *.o
 *.log
+doc/_build
+doc/_doxybuild
 pygpu/*.c
 pygpu/*.h
 pygpu/version.py

--- a/doc/c_api/file/error_8h.rst
+++ b/doc/c_api/file/error_8h.rst
@@ -1,4 +1,4 @@
 File error.h
 ============
 
-.. doxygenfile:: error.h
+.. doxygenfile:: gpuarray/error.h

--- a/src/gpuarray/error.h
+++ b/src/gpuarray/error.h
@@ -1,6 +1,6 @@
 #ifndef GPUARRAY_ERROR_H
 #define GPUARRAY_ERROR_H
-/** \file error.h
+/** \file gpuarray/error.h
  *  \brief Error functions.
  */
 


### PR DESCRIPTION
I'm still not sure why "duplicate ID" warnings show up in the Linux VMs, but not the MacOS one.