### PR TITLE
python interface for rgemmBatch_3d

### DIFF
--- a/pygpu/blas.pyx
+++ b/pygpu/blas.pyx
@@ -92,14 +92,14 @@ def gemv(double alpha, GpuArray A, GpuArray X, double beta=0.0,
         transA = cb_no_trans
 
     if A.ga.nd != 2:
-        raise TypeError, "A is not a matrix"
+        raise TypeError("A is not a matrix")
     if transA == cb_no_trans:
         Yshp = A.ga.dimensions[0]
     else:
         Yshp = A.ga.dimensions[1]
     if Y is None:
         if beta != 0.0:
-            raise ValueError, "Y not provided and beta != 0"
+            raise ValueError("Y not provided and beta != 0")
         Y = pygpu_empty(1, &Yshp, A.ga.typecode, GA_ANY_ORDER, A.context, None)
         overwrite_y = True
 
@@ -127,9 +127,9 @@ def gemm(double alpha, GpuArray A, GpuArray B, double beta, GpuArray C=None,
         transB = cb_no_trans
 
     if A.ga.nd != 2:
-        raise TypeError, "A is not a matrix"
+        raise TypeError("A is not a matrix")
     if B.ga.nd != 2:
-        raise TypeError, "B is not a matrix"
+        raise TypeError("B is not a matrix")
     if transA == cb_no_trans:
         Cshp[0] = A.ga.dimensions[0]
     else:
@@ -140,7 +140,7 @@ def gemm(double alpha, GpuArray A, GpuArray B, double beta, GpuArray C=None,
         Cshp[1] = B.ga.dimensions[0]
     if C is None:
         if beta != 0.0:
-            raise ValueError, "C not provided and beta != 0"
+            raise ValueError("C not provided and beta != 0")
         C = pygpu_empty(2, Cshp, A.ga.typecode, GA_ANY_ORDER, A.context, None)
         overwrite_c = True
 
@@ -187,9 +187,9 @@ def gemmBatch_3d(double alpha, GpuArray A, GpuArray B,
         transB = cb_no_trans
 
     if A.ga.nd != 3:
-        raise TypeError, "A is not a batch of matrices"
+        raise TypeError("A is not a batch of matrices")
     if B.ga.nd != 3:
-        raise TypeError, "B is not a batch of matrices"
+        raise TypeError("B is not a batch of matrices")
 
     Cshp[0] = A.ga.dimensions[0]
     if transA == cb_no_trans:
@@ -202,7 +202,7 @@ def gemmBatch_3d(double alpha, GpuArray A, GpuArray B,
         Cshp[2] = B.ga.dimensions[1]
     if C is None:
         if beta != 0.0:
-            raise ValueError, "C not provided and beta != 0"
+            raise ValueError("C not provided and beta != 0")
         C = pygpu_empty(3, Cshp, A.ga.typecode, GA_ANY_ORDER, A.context, None)
         overwrite_c = True
 

--- a/pygpu/blas.pyx
+++ b/pygpu/blas.pyx
@@ -204,9 +204,7 @@ def gemmBatch_3d(double alpha, GpuArray A, GpuArray B,
         if beta != 0.0:
             raise ValueError("C not provided and beta != 0")
         C = pygpu_empty(3, Cshp, A.ga.typecode, GA_ANY_ORDER, A.context, None)
-        overwrite_c = True
-
-    if not overwrite_c:
+    else:
         C = pygpu_copy(C, GA_ANY_ORDER)
     pygpu_blas_rgemmBatch_3d(transA, transB, alpha, A, B, beta, C, 0)
 

--- a/pygpu/blas.pyx
+++ b/pygpu/blas.pyx
@@ -204,7 +204,7 @@ def gemmBatch_3d(double alpha, GpuArray A, GpuArray B,
         if beta != 0.0:
             raise ValueError("C not provided and beta != 0")
         C = pygpu_empty(3, Cshp, A.ga.typecode, GA_ANY_ORDER, A.context, None)
-    else:
+    elif not overwrite_c:
         C = pygpu_copy(C, GA_ANY_ORDER)
     pygpu_blas_rgemmBatch_3d(transA, transB, alpha, A, B, beta, C, 0)
 

--- a/pygpu/tests/test_blas.py
+++ b/pygpu/tests/test_blas.py
@@ -171,19 +171,19 @@ def ger(m, n, dtype, order, sliced_x, sliced_y, init_res, overwrite=False):
 def test_rgemmBatch_3d():
     bools = [False, True]
     for b, (m, n, k), order, trans, offseted_o in product(
-        [1, 17, 31], [(24, 7, 16), (7, 16, 24)], list(product('fc', repeat=3)),
+        [1, 17, 31], [(24, 7, 16), (7, 16, 24)], list(product('fc', 'fc', 'c')),
         list(product(bools, bools)), bools):
         yield rgemmBatch_3d, b, m, n, k, 'float32', order, trans, \
             offseted_o, 1, False, False
     for sliced, overwrite, init_res in product(
         [1, 2, -1, -2], bools, bools):
-        yield rgemmBatch_3d, 5, 4, 3, 2, 'float32', ('f', 'f', 'f'), \
+        yield rgemmBatch_3d, 5, 4, 3, 2, 'float32', ('f', 'f', 'c'), \
             (False, False), False, sliced, overwrite, init_res
-    yield rgemmBatch_3d, 16, 16, 16, 16, 'float64', ('f', 'f', 'f'), (False, False), \
+    yield rgemmBatch_3d, 16, 16, 16, 16, 'float64', ('f', 'f', 'c'), (False, False), \
         False, 1, False, False
     for alpha, beta, overwrite in product(
         [0, 1, -1, 0.6], [0, 1, -1, 0.6], bools):
-        yield rgemmBatch_3d, 16, 16, 9, 16, 'float32', ('f', 'f', 'f'), \
+        yield rgemmBatch_3d, 16, 16, 9, 16, 'float32', ('f', 'f', 'c'), \
             (False, False), False, 1, overwrite, True, alpha, beta
 
 @guard_devsup


### PR DESCRIPTION
Basically c/p from gemm code.

In tests, I removed the cases where destination array is fortran-contiguous, because it would trigger an error at [here](https://github.com/Theano/libgpuarray/blob/master/src/gpuarray_array_blas.c#L540).

```c
cC = is_last_2d_contiguous(C);
  if (!cC) {
    err = GA_VALUE_ERROR;
    goto cleanup;
  }
```

The function `is_last_2d_contiguous` can't detect a rank-3 fortran-contiguous array. Because the least strided index would be 0 while this only test for the last two indices. For example:

```python
>>> x = np.random.rand(3,4,5).astype('float32')
>>> y = np.asfortranarray(x)
>>> x.strides
(80, 20, 4)
>>> y.strides
(4, 12, 48)
```

The batched gemm needs an 3d array with the 2nd stride being 4, so it's neither c-contig or f-contig as whole. I'm not sure what's the most convenient solution here.