### PR TITLE
Use secure HTTPS URLs where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ PROJECT(libgpuarray C)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 
 # -Wall is unbelieveably noisy with Visual Studio:
-# http://stackoverflow.com/q/4001736/3257826
+# https://stackoverflow.com/q/4001736/3257826
 if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W3")
 else()

--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@ with a log of the build messages to abergeron@gmail.com.
 Requirements:
 
  - either an OpenCL runtime (with headers) or the CUDA toolkit
- - CMake [ http://cmake.org ] (to build)
+ - CMake [ https://cmake.org ] (to build)
 
 Run CMake on the CMakeList.txt file in src/ and build according to
 your platform.  Set CMAKE_INSTALL_PREFIX to your desired path if you

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -9,7 +9,7 @@
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    ga.src = 'https://ssl.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 </script>

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -175,8 +175,8 @@ install step.  It is up to you to copy the headers and libraries to an
 appropriate place.
 
 If you don't have Visual Studio installed, you can get the free
-Express version from `here <http://www.visualstudio.com/>`_ in the
-downloads section (select the "for Windows" edition).
+Express version from `here <https://www.visualstudio.com/>`_ in the
+downloads section (select the "for windows" edition).
 
 .. warning::
    While you may get the library to compile using cygwin, this is not
@@ -226,7 +226,7 @@ you can confirm which device it is running on.
    only the codename of the architecture the GPU belongs to (e.g.
    'Tahiti').
 
-.. _cmake: http://cmake.org/
+.. _cmake: https://cmake.org/
 
 .. _clblas: https://github.com/clMathLibraries/clBLAS
 
@@ -238,10 +238,10 @@ you can confirm which device it is running on.
 
 .. _check: http://check.sourceforge.net/
 
-.. _python: http://python.org/
+.. _python: https://python.org/
 
 .. _cython: http://cython.org/
 
-.. _nosetests: http://nose.readthedocs.org/en/latest/
+.. _nosetests: https://nose.readthedocs.org/en/latest/
 
 .. _mako: http://www.makotemplates.org/

--- a/src/util/xxhash.c
+++ b/src/util/xxhash.c
@@ -2,7 +2,7 @@
 xxHash - Fast Hash algorithm
 Copyright (C) 2012-2015, Yann Collet
 
-BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+BSD 2-Clause License (https://opensource.org/licenses/bsd-license.php)
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/src/util/xxhash.h
+++ b/src/util/xxhash.h
@@ -6,7 +6,7 @@
    Header File
    Copyright (C) 2012-2015, Yann Collet.
 
-   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+   BSD 2-Clause License (https://opensource.org/licenses/bsd-license.php)
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Not all URLs could be converted, as there are still Web sites out there not having HTTPS set up correctly.