### PR TITLE
Use "right" ld* with 1D matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export PREFIX=$HOME/.local
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install doxygen; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PYTHONUSERBASE=$PREFIX; fi
-  - pip install --user breathe sphinx==1.5 sphinx_rtd_theme cython numpy 'mako>=0.7' six
+  - pip install --user breathe sphinx==1.5.1 sphinx_rtd_theme cython numpy 'mako>=0.7' six
   - export PATH=$PATH:$PREFIX/bin
   - export CPATH=$CPATH:$PREFIX/include
   - export LIBRARY_PATH=$LIBRARY_PATH:$PREFIX/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export PREFIX=$HOME/.local
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install doxygen; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PYTHONUSERBASE=$PREFIX; fi
-  - pip install --user breathe sphinx sphinx_rtd_theme cython numpy 'mako>=0.7' six
+  - pip install --user breathe sphinx==1.5 sphinx_rtd_theme cython numpy 'mako>=0.7' six
   - export PATH=$PATH:$PREFIX/bin
   - export CPATH=$CPATH:$PREFIX/include
   - export LIBRARY_PATH=$LIBRARY_PATH:$PREFIX/lib

--- a/src/gpuarray_array_blas.c
+++ b/src/gpuarray_array_blas.c
@@ -563,7 +563,9 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
     goto cleanup;
   }
   if (cA == 2) {
-    lda = Ap->strides[2] / elsize;
+    lda = Ap->dimensions[2] > 1
+          ? Ap->strides[2] / elsize
+          : Ap->dimensions[1];
     if (o == cb_c) {
       if (transA == cb_no_trans)
         transA = cb_trans;
@@ -571,7 +573,9 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
         transA = cb_no_trans;
     }
   } else if (cA == 1) {
-    lda = Ap->strides[1] / elsize;
+    lda = Ap->dimensions[1] > 1
+          ? Ap->strides[1] / elsize
+          : Ap->dimensions[2];
     if (o == cb_fortran) {
       if (transA == cb_no_trans)
         transA = cb_trans;

--- a/src/gpuarray_array_blas.c
+++ b/src/gpuarray_array_blas.c
@@ -550,10 +550,14 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
 
   if (cC == 2) {
     o = cb_fortran;
-    ldc = Cp->strides[2] / elsize;
+    ldc = Cp->dimensions[2] > 1
+          ? Cp->strides[2] / elsize
+          : Cp->dimensions[1];
   } else if (cC == 1) {
     o = cb_c;
-    ldc = Cp->strides[1] / elsize;
+    ldc = Cp->dimensions[1] > 1
+          ? Cp->strides[1] / elsize
+          : Cp->dimensions[2];
   } else {
     err = GA_VALUE_ERROR;
     goto cleanup;
@@ -579,7 +583,9 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
     goto cleanup;
   }
   if (cB == 2) {
-    ldb = Bp->strides[2] / elsize;
+    ldb = Bp->dimensions[2] > 1
+          ? Bp->strides[2] / elsize
+          : Bp->dimensions[1];
     if (o == cb_c) {
       if (transB == cb_no_trans)
         transB = cb_trans;
@@ -587,7 +593,9 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
         transB = cb_no_trans;
     }
   } else if (cB == 1) {
-    ldb = Bp->strides[1] / elsize;
+    ldb = Bp->dimensions[1] > 1
+          ? Bp->strides[1] / elsize
+          : Bp->dimensions[2];
     if (o == cb_fortran) {
       if (transB == cb_no_trans)
         transB = cb_trans;

--- a/src/gpuarray_array_blas.c
+++ b/src/gpuarray_array_blas.c
@@ -254,7 +254,7 @@ int GpuArray_rgemm(cb_transpose transA, cb_transpose transB, double alpha,
     else {
       err = GpuArray_copy(&copyA, A, GA_F_ORDER);
       if (err != GA_NO_ERROR)
-	goto cleanup;
+        goto cleanup;
       Ap = &copyA;
     }
   }
@@ -264,7 +264,7 @@ int GpuArray_rgemm(cb_transpose transA, cb_transpose transB, double alpha,
     else {
       err = GpuArray_copy(&copyB, B, GA_F_ORDER);
       if (err != GA_NO_ERROR)
-	goto cleanup;
+        goto cleanup;
       Bp = &copyB;
     }
   }
@@ -388,7 +388,7 @@ int GpuArray_rger(double alpha, GpuArray *X, GpuArray *Y, GpuArray *A,
     else {
       err = GpuArray_copy(&copyX, X, GA_ANY_ORDER);
       if (err != GA_NO_ERROR)
-	goto cleanup;
+        goto cleanup;
       Xp = &copyX;
     }
   }
@@ -398,7 +398,7 @@ int GpuArray_rger(double alpha, GpuArray *X, GpuArray *Y, GpuArray *A,
     else {
       err = GpuArray_copy(&copyY, Y, GA_ANY_ORDER);
       if (err != GA_NO_ERROR)
-	goto cleanup;
+        goto cleanup;
       Yp = &copyY;
     }
   }
@@ -526,7 +526,7 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
       err = GpuArray_copy(&copyA, A, GA_C_ORDER);
       cA = 1;
       if (err != GA_NO_ERROR)
-	goto cleanup;
+        goto cleanup;
       Ap = &copyA;
     }
   }
@@ -538,7 +538,7 @@ int GpuArray_rgemmBatch_3d(cb_transpose transA, cb_transpose transB, double alph
       err = GpuArray_copy(&copyB, B, GA_C_ORDER);
       cB = 1;
       if (err != GA_NO_ERROR)
-	goto cleanup;
+        goto cleanup;
       Bp = &copyB;
     }
   }


### PR DESCRIPTION
This is re-applying an old fix that was in Theano, see https://github.com/Theano/Theano/blob/master/theano/tensor/blas.py#L649-L663

This first commit fixes Theano/Theano#5730, but there are many other places lda/b/c would be considered "incorrect".

Another option might be to consider the other contiguity pattern here, but I don't know how to make sure we choose the right one.