### PR TITLE
Add offset in DEBUG

### DIFF
--- a/src/gpuarray_array.c
+++ b/src/gpuarray_array.c
@@ -119,10 +119,20 @@ int GpuArray_empty(GpuArray *a, gpucontext *ctx, int typecode,
     size *= d;
   }
 
+  /* We add a offset of 64 to all arrays in DEBUG to help catch errors. */
+#ifdef DEBUG
+  assert(SIZE_MAX - size > 64);
+  size += 64;
+#endif
+
   a->data = gpudata_alloc(ctx, size, NULL, 0, &res);
   if (a->data == NULL) return res;
   a->nd = nd;
+#ifdef DEBUG
+  a->offset = 64;
+#else
   a->offset = 0;
+#endif
   a->typecode = typecode;
   a->dimensions = calloc(nd, sizeof(size_t));
   a->strides = calloc(nd, sizeof(ssize_t));


### PR DESCRIPTION
Adds an offset to all GpuArrays in DEBUG to help catch errors where the offset is not handled appropriately.

Also fix the meaning of .gpudata/.data/.base_data to better emulate what PyCUDA/PyOpenCL does.