### PR TITLE
Use blocking_sync instead of yield when configured for multi-threading

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -501,7 +501,7 @@ static cuda_context *do_init(CUdevice dev, int flags, error *e) {
   if (flags & GA_CTX_SINGLE_THREAD)
     fl = CU_CTX_SCHED_SPIN;
   if (flags & GA_CTX_MULTI_THREAD)
-    fl = CU_CTX_SCHED_YIELD;
+    fl = CU_CTX_SCHED_BLOCKING_SYNC;
   err = cuDeviceGetAttribute(&i, CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING, dev);
   CHKFAIL(e, "cuDeviceGetAttribute", NULL);
   if (i != 1) {


### PR DESCRIPTION
As discussed in https://github.com/Theano/Theano/issues/5706, this PR changes the CUDA host/device synchronization to use blocking synchronization instead of yielding when configured for multi-threading (e.g., when `gpuarray.sched=multi` in Theano). This lowers CPU utilization and power consumption by a large margin while the CPU is waiting for the GPU.

The alternative would be to introduce a third option so one could select between spinning (the current default), yielding and blocking, but in https://github.com/Theano/Theano/issues/5706 we figured that yielding may not be that useful anyway.

Closes https://github.com/Theano/Theano/issues/5706. (Not sure if that works across project boundaries? Probably not.)