### PR TITLE
Loop over supported CUDA versions to find installed CUDA on Windows and Mac.

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -150,7 +150,7 @@ static int setup_lib(void) {
     if (res != GA_NO_ERROR) {
       /* Else, let's try to find a nvrtc corresponding to supported CUDA versions. */
       int versions[][2] = {{8, 0}, {7, 5}, {7, 0}};
-      int versions_length = sizeof(versions) / (2 * sizeof(int));
+      int versions_length = sizeof(versions) / sizeof(versions[0]);
       int i = 0;
       do {
         major = versions[i][0];

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -129,7 +129,6 @@ static int setup_done = 0;
 static int major = -1;
 static int minor = -1;
 static int setup_lib(void) {
-  const char *ver;
   CUresult err;
   int res, tmp;
 
@@ -152,12 +151,15 @@ static int setup_lib(void) {
       int versions[][2] = {{8, 0}, {7, 5}, {7, 0}};
       int versions_length = sizeof(versions) / sizeof(versions[0]);
       int i = 0;
+      /* Skip versions that are higher or equal to the driver version */
+      while (versions[i][0] > major ||
+             (versions[i][0] == major && versions[i][1] >= minor)) i++;
       do {
         major = versions[i][0];
         minor = versions[i][1];
         res = load_libnvrtc(major, minor, global_err);
-        ++i;
-      } while(res != GA_NO_ERROR && i < versions_length);
+        i++;
+      } while (res != GA_NO_ERROR && i < versions_length);
     }
     if (res != GA_NO_ERROR)
       return res;

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -132,6 +132,7 @@ static int setup_lib(void) {
   const char *ver;
   CUresult err;
   int res, tmp;
+  int search_version = 0;
 
   if (!setup_done) {
     res = load_libcuda(global_err);
@@ -147,13 +148,49 @@ static int setup_lib(void) {
         return error_set(global_err, GA_IMPL_ERROR, "cuDriverGetVersion failed");
       major = tmp / 1000;
       minor = (tmp / 10) % 10;
+      #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64) || defined(__APPLE__)
+      /* We will dynamically search the right CUDA version only on Windows and Macintosh systems,
+      and only if user has not explicitely specified GPUARRAY_CUDA_VERSION. */
+      search_version = 1;
+      #endif
     } else {
       major = ver[0] - '0';
       minor = ver[1] - '0';
     }
+    /* NB: next line will cause problems if a CUDA 10.0 (or 9.11) is released in the future. */
     if (major > 9 || major < 0 || minor > 9 || minor < 0)
       return error_fmt(global_err, GA_VALUE_ERROR, "Invalid cuda version: %d.%d", major, minor);
-    res = load_libnvrtc(major, minor, global_err);
+    if (!search_version) {
+      res = load_libnvrtc(major, minor, global_err);
+    } else {
+      /* First case in next array is reserved to eventually receive the version returned by cuDriverGetVersion(). */
+      int versions[] = {-1, 80, 75};
+      int versions_length = sizeof(versions) / sizeof(int);
+      int current_version = major * 10 + minor;
+      int i = 0;
+      for (i = 1; i < versions_length && versions[i] != current_version; ++i);
+      if (i == versions_length) {
+        /* Current version not found in the list of versions. We add it at top of the list. */
+        versions[0] = current_version;
+        /* We will iterate on versions from the first. */
+        i = 0;
+      } else {
+        /* Current version found in the list of known versions. No need to add it to the list. */
+        i = 1;
+      };
+      do {
+        major = versions[i] / 10;
+        minor = versions[i] % 10;
+        res = load_libnvrtc(major, minor, global_err);
+        ++i;
+      } while(res != GA_NO_ERROR && i < versions_length);
+      #ifdef DEBUG
+      if (res == GA_NO_ERROR)
+        fprintf(stderr, "Detected CUDA %d.%d.\n", major, minor);
+      else
+        fprintf(stderr, "Unable to detect a CUDA version.\n");
+      #endif
+    }
     if (res != GA_NO_ERROR)
       return res;
     setup_done = 1;

--- a/src/loaders/libcublas.c
+++ b/src/loaders/libcublas.c
@@ -45,24 +45,22 @@ int load_libcublas(int major, int minor, error *e) {
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
   {
-    static const char DIGITS[] = "0123456789";
-    char libname[] = "cublas64_??.dll";
+    const char* libname_pattern = "cublas64_%d%d.dll";
+    char libname[64];
 
     #ifdef DEBUG
     fprintf(stderr, "Loading cuBLAS %d.%d.\n", major, minor);
     #endif
-    libname[9] = DIGITS[major];
-    libname[10] = DIGITS[minor];
+    sprintf(libname, libname_pattern, major, minor);
 
     lib = ga_load_library(libname, e);
   }
 #else /* Unix */
 #ifdef __APPLE__
   {
-    static const char DIGITS[] = "0123456789";
-    char libname[] = "/Developer/NVIDIA/CUDA-?.?/lib/libcublas.dylib";
-    libname[23] = DIGITS[major];
-    libname[25] = DIGITS[minor];
+    const char* libname_pattern = "/Developer/NVIDIA/CUDA-%d.%d/lib/libcublas.dylib";
+    char libname[128];
+    sprintf(libname, libname_pattern, major, minor);
     lib = ga_load_library(libname, e);
   }
 #else

--- a/src/loaders/libcublas.c
+++ b/src/loaders/libcublas.c
@@ -1,8 +1,5 @@
-#include <stdlib.h>
-#ifdef DEBUG
-/* For fprintf and stderr. */
-#include <stdio.h>
-#endif
+/* To be able to use snprintf with any compiler including MSVC2008. */
+#include <private_config.h>
 
 #include "libcublas.h"
 #include "dyn_load.h"
@@ -45,22 +42,27 @@ int load_libcublas(int major, int minor, error *e) {
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
   {
-    const char* libname_pattern = "cublas64_%d%d.dll";
     char libname[64];
-
+    int n;
     #ifdef DEBUG
     fprintf(stderr, "Loading cuBLAS %d.%d.\n", major, minor);
     #endif
-    sprintf(libname, libname_pattern, major, minor);
-
+    n = snprintf(libname, 64, "cublas64_%d%d.dll", major, minor);
+    if (n < 0 || n >= 64)
+      return error_set(e, GA_SYS_ERROR, "cublas library name too long.");
     lib = ga_load_library(libname, e);
   }
 #else /* Unix */
 #ifdef __APPLE__
   {
-    const char* libname_pattern = "/Developer/NVIDIA/CUDA-%d.%d/lib/libcublas.dylib";
     char libname[128];
-    sprintf(libname, libname_pattern, major, minor);
+    int n;
+    #ifdef DEBUG
+    fprintf(stderr, "Loading cuBLAS %d.%d.\n", major, minor);
+    #endif
+    n = snprintf(libname, 128, "/Developer/NVIDIA/CUDA-%d.%d/lib/libcublas.dylib", major, minor);
+    if (n < 0 || n >= 128)
+      return error_set(e, GA_SYS_ERROR, "cublas library path too long.");
     lib = ga_load_library(libname, e);
   }
 #else

--- a/src/loaders/libcublas.c
+++ b/src/loaders/libcublas.c
@@ -1,4 +1,8 @@
 #include <stdlib.h>
+#ifdef DEBUG
+/* For fprintf and stderr. */
+#include <stdio.h>
+#endif
 
 #include "libcublas.h"
 #include "dyn_load.h"

--- a/src/loaders/libcublas.c
+++ b/src/loaders/libcublas.c
@@ -47,9 +47,9 @@ int load_libcublas(int major, int minor, error *e) {
     #ifdef DEBUG
     fprintf(stderr, "Loading cuBLAS %d.%d.\n", major, minor);
     #endif
-    n = snprintf(libname, 64, "cublas64_%d%d.dll", major, minor);
-    if (n < 0 || n >= 64)
-      return error_set(e, GA_SYS_ERROR, "cublas library name too long.");
+    n = snprintf(libname, sizeof(libname), "cublas64_%d%d.dll", major, minor);
+    if (n < 0 || n >= sizeof(libname))
+      return error_set(e, GA_SYS_ERROR, "snprintf");
     lib = ga_load_library(libname, e);
   }
 #else /* Unix */
@@ -60,9 +60,9 @@ int load_libcublas(int major, int minor, error *e) {
     #ifdef DEBUG
     fprintf(stderr, "Loading cuBLAS %d.%d.\n", major, minor);
     #endif
-    n = snprintf(libname, 128, "/Developer/NVIDIA/CUDA-%d.%d/lib/libcublas.dylib", major, minor);
-    if (n < 0 || n >= 128)
-      return error_set(e, GA_SYS_ERROR, "cublas library path too long.");
+    n = snprintf(libname, sizeof(libname), "/Developer/NVIDIA/CUDA-%d.%d/lib/libcublas.dylib", major, minor);
+    if (n < 0 || n >= sizeof(libname))
+      return error_set(e, GA_SYS_ERROR, "snprintf");
     lib = ga_load_library(libname, e);
   }
 #else

--- a/src/loaders/libcublas.c
+++ b/src/loaders/libcublas.c
@@ -44,6 +44,9 @@ int load_libcublas(int major, int minor, error *e) {
     static const char DIGITS[] = "0123456789";
     char libname[] = "cublas64_??.dll";
 
+    #ifdef DEBUG
+    fprintf(stderr, "Loading cuBLAS %d.%d.\n", major, minor);
+    #endif
     libname[9] = DIGITS[major];
     libname[10] = DIGITS[minor];
 

--- a/src/loaders/libnvrtc.c
+++ b/src/loaders/libnvrtc.c
@@ -33,24 +33,23 @@ int load_libnvrtc(int major, int minor, error *e) {
     #ifdef DEBUG
     fprintf(stderr, "Loading nvrtc %d.%d.\n", major, minor);
     #endif
-    n = snprintf(libname, 64, "nvrtc64_%d%d.dll", major, minor);
-    if (n < 0 || n >= 64)
-      return error_set(e, GA_SYS_ERROR, "nvrtc library name too long.");
+    n = snprintf(libname, sizeof(libname), "nvrtc64_%d%d.dll", major, minor);
+    if (n < 0 || n >= sizeof(libname))
+      return error_set(e, GA_SYS_ERROR, "snprintf");
 
     lib = ga_load_library(libname, e);
   }
 #else /* Unix */
 #ifdef __APPLE__
   {
-    /* Try the usual fullpath first */
     char libname[128];
     int n;
     #ifdef DEBUG
     fprintf(stderr, "Loading nvrtc %d.%d.\n", major, minor);
     #endif
-    n = snprintf(libname, 128, "/Developer/NVIDIA/CUDA-%d.%d/lib/libnvrtc.dylib", major, minor);
-    if (n < 0 || n >= 128)
-      return error_set(e, GA_SYS_ERROR, "nvrtc library path too long.");
+    n = snprintf(libname, sizeof(libname), "/Developer/NVIDIA/CUDA-%d.%d/lib/libnvrtc.dylib", major, minor);
+    if (n < 0 || n >= sizeof(libname))
+      return error_set(e, GA_SYS_ERROR, "snprintf");
     lib = ga_load_library(libname, e);
   }
 #else

--- a/src/loaders/libnvrtc.c
+++ b/src/loaders/libnvrtc.c
@@ -1,4 +1,8 @@
 #include <stdlib.h>
+#ifdef DEBUG
+/* For fprintf and stderr. */
+#include <stdio.h>
+#endif
 
 #include "libcuda.h"
 #include "libnvrtc.h"
@@ -27,22 +31,23 @@ int load_libnvrtc(int major, int minor, error *e) {
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
   {
-    static const char DIGITS[] = "0123456789";
-    char libname[] = "nvrtc64_??.dll";
+    const char* libname_pattern = "nvrtc64_%d%d.dll";
+    char libname[64];
 
-    libname[8] = DIGITS[major];
-    libname[9] = DIGITS[minor];
+    #ifdef DEBUG
+    fprintf(stderr, "Loading nvrtc %d.%d.\n", major, minor);
+    #endif
+    sprintf(libname, libname_pattern, major, minor);
 
     lib = ga_load_library(libname, e);
   }
 #else /* Unix */
 #ifdef __APPLE__
   {
-    static const char DIGITS[] = "0123456789";
     /* Try the usual fullpath first */
-    char libname[] = "/Developer/NVIDIA/CUDA-?.?/lib/libnvrtc.dylib";
-    libname[23] = DIGITS[major];
-    libname[25] = DIGITS[minor];
+    const char* libname_pattern = "/Developer/NVIDIA/CUDA-%d.%d/lib/libnvrtc.dylib";
+    char libname[128];
+    sprintf(libname, libname_pattern, major, minor);
     lib = ga_load_library(libname, e);
   }
 #else

--- a/src/loaders/libnvrtc.c
+++ b/src/loaders/libnvrtc.c
@@ -1,8 +1,5 @@
-#include <stdlib.h>
-#ifdef DEBUG
-/* For fprintf and stderr. */
-#include <stdio.h>
-#endif
+/* To be able to use snprintf with any compiler including MSVC2008. */
+#include <private_config.h>
 
 #include "libcuda.h"
 #include "libnvrtc.h"
@@ -31,13 +28,14 @@ int load_libnvrtc(int major, int minor, error *e) {
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
   {
-    const char* libname_pattern = "nvrtc64_%d%d.dll";
     char libname[64];
-
+    int n;
     #ifdef DEBUG
     fprintf(stderr, "Loading nvrtc %d.%d.\n", major, minor);
     #endif
-    sprintf(libname, libname_pattern, major, minor);
+    n = snprintf(libname, 64, "nvrtc64_%d%d.dll", major, minor);
+    if (n < 0 || n >= 64)
+      return error_set(e, GA_SYS_ERROR, "nvrtc library name too long.");
 
     lib = ga_load_library(libname, e);
   }
@@ -45,9 +43,14 @@ int load_libnvrtc(int major, int minor, error *e) {
 #ifdef __APPLE__
   {
     /* Try the usual fullpath first */
-    const char* libname_pattern = "/Developer/NVIDIA/CUDA-%d.%d/lib/libnvrtc.dylib";
     char libname[128];
-    sprintf(libname, libname_pattern, major, minor);
+    int n;
+    #ifdef DEBUG
+    fprintf(stderr, "Loading nvrtc %d.%d.\n", major, minor);
+    #endif
+    n = snprintf(libname, 128, "/Developer/NVIDIA/CUDA-%d.%d/lib/libnvrtc.dylib", major, minor);
+    if (n < 0 || n >= 128)
+      return error_set(e, GA_SYS_ERROR, "nvrtc library path too long.");
     lib = ga_load_library(libname, e);
   }
 #else


### PR DESCRIPTION
Fix #472 . Tested on my Windows 8.1 64 bits with Python 2.7.13 Anaconda 64 bits.

When compiled as Debug version:
```
(python2) HPPC@NOTORAPTOR-HP C:\Users\HPPC\mila\dev\git\theano
> echo %THEANO_FLAGS%
device=cuda0

(python2) HPPC@NOTORAPTOR-HP C:\Users\HPPC\mila\dev\git\theano
> python -c "import theano"
ERROR 18: Could not load "nvrtc64_90.dll": Le module spécifié est introuvable.

Detected CUDA 8.0.
Loading cuBLAS 8.0.
Using cuDNN version 6020 on context None
Mapped name None to device cuda0: GeForce 840M (0000:0A:00.0)
```

@nouiz @abergeron @lamblin .