### PR TITLE
Fix segfault in Theano 0.9

### DIFF
--- a/src/gpuarray_buffer.c
+++ b/src/gpuarray_buffer.c
@@ -162,7 +162,7 @@ gpukernel *gpukernel_init(gpucontext *ctx, unsigned int count,
                           const char *fname, unsigned int numargs,
                           const int *typecodes, int flags, int *ret,
                           char **err_str) {
-  gpukernel *res;
+  gpukernel *res = NULL;
   int err;
   err = ctx->ops->kernel_alloc(&res, ctx, count, strings, lengths, fname,
                                numargs, typecodes, flags, err_str);

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -740,12 +740,12 @@ void GpuElemwise_free(GpuElemwise *ge) {
 }
 
 int GpuElemwise_call(GpuElemwise *ge, void **args, int flags) {
-  size_t n;
-  size_t *dims;
-  ssize_t **strides;
-  unsigned int nd;
-  int contig;
-  int call32;
+  size_t n = 0;
+  size_t *dims = NULL;
+  ssize_t **strides = NULL;
+  unsigned int nd = 0;
+  int contig = 0;
+  int call32 = 0;
   int err;
 
   err = check_contig(ge, args, &n, &contig);


### PR DESCRIPTION
This fixes a problem that would make GpuKernel_init() segfault when there was an error creating the kernel.

This was exacerbated by the fact that Theano 0.9 will try to precompile kernels to binary and load them back which isn't supported anymore, and would trigger an error.
