### PR TITLE
Trivial Fixes related to #481.

### DIFF
--- a/src/cache/lru.c
+++ b/src/cache/lru.c
@@ -114,15 +114,14 @@ struct _hash {
   size_t size;
 };
 
-static inline size_t roundup2(size_t s) {
+static inline unsigned long long roundup2(unsigned long long s) {
   s--;
   s |= s >> 1;
   s |= s >> 2;
   s |= s >> 4;
   s |= s >> 8;
   s |= s >> 16;
-  if (sizeof(size_t) >= 8)
-    s |= s >> 32;
+  s |= s >> 32;
   s++;
   return s;
 }

--- a/src/cache/twoq.c
+++ b/src/cache/twoq.c
@@ -124,15 +124,14 @@ struct _hash {
   size_t size;
 };
 
-static inline size_t roundup2(size_t s) {
+static inline unsigned long long roundup2(unsigned long long s) {
   s--;
   s |= s >> 1;
   s |= s >> 2;
   s |= s >> 4;
   s |= s >> 8;
   s |= s >> 16;
-  if (sizeof(size_t) >= 8)
-    s |= s >> 32;
+  s |= s >> 32;
   s++;
   return s;
 }

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -757,7 +757,7 @@ static int cl_memset(gpudata *dst, size_t offset, int data) {
                  offset, n, val);
   }
   /* If this assert fires, increase the size of local_kern above. */
-  assert(r <= sizeof(local_kern));
+  assert(r <= (int)sizeof(local_kern));
   _unused(r);
 
   sz = strlen(local_kern);

--- a/src/gpuarray_elemwise.c
+++ b/src/gpuarray_elemwise.c
@@ -740,12 +740,12 @@ void GpuElemwise_free(GpuElemwise *ge) {
 }
 
 int GpuElemwise_call(GpuElemwise *ge, void **args, int flags) {
-  size_t n;
-  size_t *dims;
-  ssize_t **strides;
-  unsigned int nd;
-  int contig;
-  int call32;
+  size_t n = 0;
+  size_t *dims = NULL;
+  ssize_t **strides = NULL;
+  unsigned int nd = 0;
+  int contig = 0;
+  int call32 = 0;
   int err;
 
   err = check_contig(ge, args, &n, &contig);

--- a/src/util/integerfactoring.c
+++ b/src/util/integerfactoring.c
@@ -266,7 +266,7 @@ static uint64_t gaIMulMod    (uint64_t a, uint64_t b, uint64_t m){
 	);
 
 	return r;
-#elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#elif ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ >= 16
 	/* Hardcore GCC 4.6+ optimization jazz */
 	return ((unsigned __int128)a * (unsigned __int128)b) % m;
 #else


### PR DESCRIPTION
A compiler error fix for #481, plus many errors reported when `-Wall -Wextra` is in use, including all the errors [here](https://buildd.debian.org/status/fetch.php?pkg=libgpuarray&arch=i386&ver=0.6.8-1&stamp=1500376646&raw=0).

Note that certain warnings appear only at `-O0` and some only at `-O2`, so it's important to build in both release and debug mode to see fresh warnings.