### PR TITLE
Muzzle -Wdeclaration-after-statement and upgrade warning flag strictness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W3")
 else()
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Werror=format-security -Wdeclaration-after-statement -std=gnu89")
 endif()
 
 enable_testing()

--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -80,19 +80,18 @@ START_TEST(test_contig_f16) {
   GpuElemwise *ge;
 
   static uint16_t data1[3];
+  static uint16_t data2[3];
+  uint16_t data3[3] = {0};
+  size_t dims[1];
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
   data1[0] = F16[1];
   data1[1] = F16[2];
   data1[2] = F16[3];
-  static uint16_t data2[3];
   data2[0] = F16[4];
   data2[1] = F16[5];
   data2[2] = F16[6];
-  uint16_t data3[3] = {0};
-
-  size_t dims[1];
-
-  gpuelemwise_arg args[3] = {{0}};
-  void *rargs[3];
 
   dims[0] = 3;
 
@@ -243,19 +242,19 @@ START_TEST(test_basic_f16) {
   GpuElemwise *ge;
 
   static uint16_t data1[3];
+  static uint16_t data2[3];
+  uint16_t data3[3] = {0};
+  size_t dims[2];
+  gpuelemwise_arg args[3] = {{0}};
+  void *rargs[3];
+
   data1[0] = F16[1];
   data1[1] = F16[2];
   data1[2] = F16[3];
-  static uint16_t data2[3];
   data2[0] = F16[4];
   data2[1] = F16[5];
   data2[2] = F16[6];
-  uint16_t data3[3] = {0};
 
-  size_t dims[2];
-
-  gpuelemwise_arg args[3] = {{0}};
-  void *rargs[3];
 
   dims[0] = 1;
   dims[1] = 3;

--- a/tests/check_reduction.c
+++ b/tests/check_reduction.c
@@ -68,13 +68,14 @@ static       double   pcgRand01(void){
  */
 
 START_TEST(test_reduction){
-	pcgSeed(1);
-
 	/**
 	 * We test here a reduction of some random 3D tensor on the first and
 	 * third dimensions.
 	 */
 
+	GpuArray gaSrc;
+	GpuArray gaMax;
+	GpuArray gaArgmax;
 	size_t i,j,k;
 	size_t dims[3]  = {32,50,79};
 	size_t prodDims = dims[0]*dims[1]*dims[2];
@@ -93,6 +94,7 @@ START_TEST(test_reduction){
 	 * Initialize source data.
 	 */
 
+	pcgSeed(1);
 	for(i=0;i<prodDims;i++){
 		pSrc[i] = pcgRand01();
 	}
@@ -101,10 +103,6 @@ START_TEST(test_reduction){
 	/**
 	 * Run the kernel.
 	 */
-
-	GpuArray gaSrc;
-	GpuArray gaMax;
-	GpuArray gaArgmax;
 
 	ga_assert_ok(GpuArray_empty(&gaSrc,    ctx, GA_FLOAT, 3, &dims[0], GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaMax,    ctx, GA_FLOAT, 1, &dims[1], GA_C_ORDER));
@@ -156,8 +154,6 @@ START_TEST(test_reduction){
 }END_TEST
 
 START_TEST(test_idxtranspose){
-	pcgSeed(1);
-
 	/**
 	 * We test here the same reduction as test_reduction, except with a
 	 * reversed reduxList {2,0} instead of {0,2}. That should lead to a
@@ -165,6 +161,9 @@ START_TEST(test_idxtranspose){
 	 * "flattened" output version.
 	 */
 
+	GpuArray gaSrc;
+	GpuArray gaMax;
+	GpuArray gaArgmax;
 	size_t i,j,k;
 	size_t dims[3]     = {32,50,79};
 	size_t prodDims    = dims[0]*dims[1]*dims[2];
@@ -185,6 +184,7 @@ START_TEST(test_idxtranspose){
 	 * Initialize source data.
 	 */
 
+	pcgSeed(1);
 	for(i=0;i<prodDims;i++){
 		pSrc[i] = pcgRand01();
 	}
@@ -193,10 +193,6 @@ START_TEST(test_idxtranspose){
 	/**
 	 * Run the kernel.
 	 */
-
-	GpuArray gaSrc;
-	GpuArray gaMax;
-	GpuArray gaArgmax;
 
 	ga_assert_ok(GpuArray_empty(&gaSrc,    ctx, GA_FLOAT, 3, dims,    GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaMax,    ctx, GA_FLOAT, 1, rdxDims, GA_C_ORDER));
@@ -248,12 +244,14 @@ START_TEST(test_idxtranspose){
 }END_TEST
 
 START_TEST(test_veryhighrank){
-	pcgSeed(1);
-
 	/**
 	 * Here we test a reduction of a random 8D tensor on four dimensions.
 	 */
 
+	GpuArray gaSrc;
+	GpuArray gaMax;
+	GpuArray gaArgmax;
+	size_t dstIdx;
 	size_t i,j,k,l,m,n,o,p;
 	size_t dims   [8]  = {1171,373,2,1,2,1,2,1};
 	size_t prodDims    = dims[0]*dims[1]*dims[2]*dims[3]*dims[4]*dims[5]*dims[6]*dims[7];
@@ -274,6 +272,7 @@ START_TEST(test_veryhighrank){
 	 * Initialize source data.
 	 */
 
+	pcgSeed(1);
 	for(i=0;i<prodDims;i++){
 		pSrc[i] = pcgRand01();
 	}
@@ -282,10 +281,6 @@ START_TEST(test_veryhighrank){
 	/**
 	 * Run the kernel.
 	 */
-
-	GpuArray gaSrc;
-	GpuArray gaMax;
-	GpuArray gaArgmax;
 
 	ga_assert_ok(GpuArray_empty(&gaSrc,    ctx, GA_FLOAT, 8, dims,    GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaMax,    ctx, GA_FLOAT, 4, rdxDims, GA_C_ORDER));
@@ -327,7 +322,7 @@ START_TEST(test_veryhighrank){
 						}
 					}
 
-					size_t dstIdx = (((i)*dims[1] + j)*dims[3] + l)*dims[6] + o;
+					dstIdx = (((i)*dims[1] + j)*dims[3] + l)*dims[6] + o;
 					ck_assert_msg(gtMax    == pMax[dstIdx],    "Max value mismatch!");
 					ck_assert_msg(gtArgmax == pArgmax[dstIdx], "Argmax value mismatch!");
 				}
@@ -349,16 +344,19 @@ START_TEST(test_veryhighrank){
 }END_TEST
 
 START_TEST(test_alldimsreduced){
-	pcgSeed(1);
-
 	/**
 	 * We test here a reduction of some random 3D tensor on all dimensions.
 	 */
 
+	GpuArray gaSrc;
+	GpuArray gaMax;
+	GpuArray gaArgmax;
 	size_t i,j,k;
 	size_t dims[3]  = {32,50,79};
 	size_t prodDims = dims[0]*dims[1]*dims[2];
 	const unsigned reduxList[] = {0,1,2};
+	size_t gtArgmax;
+	float  gtMax;
 
 	float*  pSrc    = calloc(1, sizeof(*pSrc)    * dims[0]*dims[1]*dims[2]);
 	float*  pMax    = calloc(1, sizeof(*pMax)                             );
@@ -373,6 +371,7 @@ START_TEST(test_alldimsreduced){
 	 * Initialize source data.
 	 */
 
+	pcgSeed(1);
 	for(i=0;i<prodDims;i++){
 		pSrc[i] = pcgRand01();
 	}
@@ -381,10 +380,6 @@ START_TEST(test_alldimsreduced){
 	/**
 	 * Run the kernel.
 	 */
-
-	GpuArray gaSrc;
-	GpuArray gaMax;
-	GpuArray gaArgmax;
 
 	ga_assert_ok(GpuArray_empty(&gaSrc,    ctx, GA_FLOAT, 3, &dims[0], GA_C_ORDER));
 	ga_assert_ok(GpuArray_empty(&gaMax,    ctx, GA_FLOAT, 0, NULL,     GA_C_ORDER));
@@ -404,8 +399,8 @@ START_TEST(test_alldimsreduced){
 	 * Check that the destination tensors are correct.
 	 */
 
-	size_t gtArgmax = 0;
-	float  gtMax    = pSrc[0];
+	gtArgmax = 0;
+	gtMax    = pSrc[0];
 
 	for(i=0;i<dims[0];i++){
 		for(j=0;j<dims[1];j++){

--- a/tests/communicator.c
+++ b/tests/communicator.c
@@ -21,11 +21,13 @@ extern void teardown(void);
  */
 void setup_comm(void)
 {
-  setup();
   int err;
+  gpucommCliqueId comm_id;
+
+  setup();
 
   MPI_Barrier(MPI_COMM_WORLD);
-  gpucommCliqueId comm_id;
+
   err = gpucomm_gen_clique_id(ctx, &comm_id);
   // Has successfully got a unique comm id.
   ck_assert_int_eq(err, GA_NO_ERROR);

--- a/tests/main.c
+++ b/tests/main.c
@@ -15,6 +15,10 @@ extern Suite *get_suite(void);
 
 int main(int argc, char *argv[])
 {
+  int number_failed;
+  Suite *s;
+  SRunner *sr;
+
 #ifdef TEST_COLLECTIVES
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &comm_ndev);
@@ -29,9 +33,8 @@ int main(int argc, char *argv[])
   dev_name = argv[comm_rank + 1];  // Set a gpu for this process.
 #endif  // TEST_COLLECTIVES
 
-  int number_failed;
-  Suite *s = get_suite();
-  SRunner *sr = srunner_create(s);
+  s = get_suite();
+  sr = srunner_create(s);
 #ifdef TEST_COLLECTIVES
   // Check by default forks to another (non mpi registered) process in order to
   // run tests. Using MPI inside tests means we must disable this.


### PR DESCRIPTION
Issue #481 brought to the fore the problem that our compiler flags are not as strict as Debian's. My PR #483 solved both an error and most compiler warnings under the Debian flags.

## Muzzle warnings

The one remaining flag that gave us grief was `-Wdeclaration-after-statement`, which essentially enforces the C90 requirement (imposed upon us by MSVC) of all declarations being upfront in a scope. All files in the codebase except those under `tests/` were already `-Wdeclaration-after-statement`-clean; This PR makes the remainder `-Wdeclaration-after-statement`-clean as well.

## Upgrade warning flag strictness

The entire codebase as I can build it on my machine (OpenMPI & CUDA enabled) now compiles with **NO** warnings or errors with the following flags on GCC 6.2.1:

    -Wall
    -Wextra
    -Wno-unused-parameter
    -Werror=format-security
    -Wdate-time
    -Wdeclaration-after-statement
    -std=gnu89

Upgrade default warnings to roughly match Debian. We're still missing:

- `-Wdate-time`, because only supported on GCC 4.9+ and the buildbot has GCC 4.6.3.
- `-fstack-protector-strong`, because it's a hardening flag that affects the compiled code.
- `-D_FORTIFY_SOURCE=2`, because it's a hardening flag that affects the compiled code.
