### PR TITLE
Try to fix theano error related to sgerBatch.

### DIFF
--- a/src/gpuarray_blas_cuda_cublas.c
+++ b/src/gpuarray_blas_cuda_cublas.c
@@ -1766,9 +1766,9 @@ static int dgerBatch(cb_order order, size_t M, size_t N, double alpha,
   }
 
   for (i = 0; i < batchCount; i++) {
-    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(A[i], CUDA_WAIT_READ));
+    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(A[i], CUDA_WAIT_ALL));
     GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(x[i], CUDA_WAIT_READ));
-    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(y[i], CUDA_WAIT_ALL));
+    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(y[i], CUDA_WAIT_READ));
   }
 
   cuda_exit(ctx);

--- a/src/gpuarray_blas_cuda_cublas.c
+++ b/src/gpuarray_blas_cuda_cublas.c
@@ -1636,9 +1636,9 @@ static int sgerBatch(cb_order order, size_t M, size_t N, float alpha,
 
 
   for (i = 0; i < batchCount; i++) {
-    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(A[i], CUDA_WAIT_READ));
+    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(A[i], CUDA_WAIT_ALL));
     GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(x[i], CUDA_WAIT_READ));
-    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(y[i], CUDA_WAIT_ALL));
+    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_record(y[i], CUDA_WAIT_READ));
   }
 
   cuda_exit(ctx);


### PR DESCRIPTION
On my computer, this seems to fix errors reported here: http://earlgrey.iro.umontreal.ca:8080/job/Theano_pr_win/44/

Parameter `A` for `sgerBatch` should be the one that is read and written, but current code call `cuda_record` to that parameter with flag `CUDA_WAIT_READ`. This PR fixes it.

NB: I have not applied the fix to the other similar functions (e.g. `dgerBatch`, etc.), I prefer post the PR first, so that we can discuss about the problems. If it is really the right error, then I will fix it in the other functions.

@nouiz @abergeron @lamblin 