### PR TITLE
CUDA race conditions 

### DIFF
--- a/src/gpuarray_blas_cuda_cublas.c
+++ b/src/gpuarray_blas_cuda_cublas.c
@@ -835,8 +835,7 @@ static int sgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
       return ctx->err->code;
     }
 
-	// added cuda_wait
-	GA_CUDA_EXIT_ON_ERROR(ctx, cuda_wait(Ta, CUDA_WAIT_ALL));
+    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_wait(Ta, CUDA_WAIT_READ));
 
     err = cublasSgemmBatched(h->h,
                              convT(transA), convT(transB),
@@ -965,8 +964,7 @@ static int dgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
       return ctx->err->code;
     }
 
-	// added cuda_wait
-	GA_CUDA_EXIT_ON_ERROR(ctx, cuda_wait(Ta, CUDA_WAIT_ALL));
+    GA_CUDA_EXIT_ON_ERROR(ctx, cuda_wait(Ta, CUDA_WAIT_READ));
 
     err = cublasDgemmBatched(h->h,
                              convT(transA), convT(transB),

--- a/src/gpuarray_blas_cuda_cublas.c
+++ b/src/gpuarray_blas_cuda_cublas.c
@@ -835,6 +835,9 @@ static int sgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
       return ctx->err->code;
     }
 
+	// added cuda_wait
+	GA_CUDA_EXIT_ON_ERROR(ctx, cuda_wait(Ta, CUDA_WAIT_ALL));
+
     err = cublasSgemmBatched(h->h,
                              convT(transA), convT(transB),
                              M, N, K, &alpha,
@@ -961,6 +964,9 @@ static int dgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
       cuda_exit(ctx);
       return ctx->err->code;
     }
+
+	// added cuda_wait
+	GA_CUDA_EXIT_ON_ERROR(ctx, cuda_wait(Ta, CUDA_WAIT_ALL));
 
     err = cublasDgemmBatched(h->h,
                              convT(transA), convT(transB),


### PR DESCRIPTION
HostFromGpu -> GpuArray_read() -> gpudata_read() -> cuda_read() -> cuMemcpyDtoHAsync()`returns 700 and then takes an exit path

```
Okay so after 3h of debugging, we know that in @shawntan's minimal testcase, `HostFromGpu -> GpuArray_read() -> gpudata_read() -> cuda_read() -> cuMemcpyDtoHAsync()` returns 700 and then takes an exit path that causes `GpuArray_read()` to return 3.

By @obilaniu

@shawntan @dendisuhubdy

Hey, just a random guess, should be easy to test.

Could you please, in current `master`, file `src/gpuarray_blas_cuda_cublas.c`, insert

    `GA_CUDA_EXIT_ON_ERROR(ctx, cuda_wait(Ta, CUDA_WAIT_ALL));`

_immediately before_ the call to `cublasSgemmBatched()` at line 855 and `cublasDgemmBatched()` at line 982?

I can see a potential failure to upload the pointers "in time" on stream `mem_s`, and such a failure would be consistent with INVALID_ADDRESS being generated in cuBLAS code and asynchronously reported in HostFromGpu.
```