### PR TITLE
check_elemwise: Fix array size.

### DIFF
--- a/tests/check_elemwise.c
+++ b/tests/check_elemwise.c
@@ -371,7 +371,7 @@ START_TEST(test_basic_scalar) {
   GpuElemwise *ge;
 
   static const uint32_t data1[3] = {1, 2, 3};
-  static const uint32_t data2[3] = {4, 5};
+  static const uint32_t data2[2] = {4, 5};
   uint32_t data3[6] = {0};
 
   size_t dims[2];


### PR DESCRIPTION
Fixes failure when trying to write 12B to 8B buffer

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>