### PR TITLE
add CUDA 9 version when trying to load libnvrtc

### DIFF
--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -176,7 +176,7 @@ static int setup_lib(void) {
     res = load_libnvrtc(major, minor, global_err);
     if (res != GA_NO_ERROR) {
       /* Else, let's try to find a nvrtc corresponding to supported CUDA versions. */
-      int versions[][2] = {{8, 0}, {7, 5}, {7, 0}};
+      int versions[][2] = {{9, 0}, {8, 0}, {7, 5}, {7, 0}};
       int versions_length = sizeof(versions) / sizeof(versions[0]);
       int i = 0;
       /* Skip versions that are higher or equal to the driver version */


### PR DESCRIPTION
With the last CUDA SDK and cuDriverGetVersion, I get major=9 and minor=1 but nvrtc64_91.dll does not exist. It is still nvrtc64_90.dll. So the code fails to load the lib and look for other versions and CUDA 9 was not in the list. Now it is.