### PR TITLE
Add 9.1 to the list of versions that windows looks for.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - export PREFIX=$HOME/.local
   - brew update && brew install doxygen
   - export PYTHONUSERBASE=$PREFIX
-  - pip install --user breathe sphinx==1.6.3 sphinx_rtd_theme cython numpy 'mako>=0.7' six
+  - pip2 install --user breathe sphinx==1.6.3 sphinx_rtd_theme cython numpy 'mako>=0.7' six
   - export PATH=$PATH:$PREFIX/bin
   - export CPATH=$CPATH:$PREFIX/include
   - export LIBRARY_PATH=$LIBRARY_PATH:$PREFIX/lib

--- a/src/gpuarray_buffer_cuda.c
+++ b/src/gpuarray_buffer_cuda.c
@@ -176,7 +176,7 @@ static int setup_lib(void) {
     res = load_libnvrtc(major, minor, global_err);
     if (res != GA_NO_ERROR) {
       /* Else, let's try to find a nvrtc corresponding to supported CUDA versions. */
-      int versions[][2] = {{9, 0}, {8, 0}, {7, 5}, {7, 0}};
+      int versions[][2] = {{9, 1}, {9, 0}, {8, 0}, {7, 5}, {7, 0}};
       int versions_length = sizeof(versions) / sizeof(versions[0]);
       int i = 0;
       /* Skip versions that are higher or equal to the driver version */


### PR DESCRIPTION
This is the only change required to support cuda 9.1.  It's mostly a bugfix release with regards to 9.0.