### PR TITLE
Give a user-friendly error when double precision is not supported

### DIFF
--- a/pygpu/_elemwise.pyx
+++ b/pygpu/_elemwise.pyx
@@ -1,4 +1,4 @@
-from pygpu.gpuarray import GpuArrayException
+from pygpu.gpuarray import GpuArrayException, UnsupportedException
 from pygpu.gpuarray cimport (gpucontext, GA_NO_ERROR, get_typecode,
                              typecode_to_dtype, GpuContext, GpuArray,
                              get_exc, gpuarray_get_elsize)
@@ -147,7 +147,10 @@ cdef class GpuElemwise:
             free(_args)
         if self.ge is NULL:
             error_message = gpucontext_error(ctx.ctx, 0).decode(encoding='latin-1')
-            raise GpuArrayException("Could not initialize C GpuElemwise instance: " + error_message)
+            # getting the error type this way is fragile, but the alternative is breaking ABI
+            raise (UnsupportedException if
+            "This device does not support double precision" in error_message else
+             GpuArrayException)("Could not initialize C GpuElemwise instance: " + error_message)
 
     def __dealloc__(self):
         cdef unsigned int i

--- a/pygpu/tests/test_basic.py
+++ b/pygpu/tests/test_basic.py
@@ -2,7 +2,7 @@ import pygpu
 
 from pygpu.basic import (tril, triu)
 from unittest import TestCase
-from .support import (gen_gpuarray, context)
+from .support import (guard_devsup, gen_gpuarray, context)
 import numpy
 
 
@@ -11,14 +11,17 @@ def test_tril():
         for shape in [(10, 5), (5, 10), (10, 10)]:
             for order in ['c', 'f']:
                 for inplace in [True, False]:
-                    ac, ag = gen_gpuarray(shape, dtype,
-                                          order=order, ctx=context)
-                    result = tril(ag, inplace=inplace)
-                    assert numpy.all(numpy.tril(ac) == result)
-                    if inplace:
-                        assert numpy.all(numpy.tril(ac) == ag)
-                    else:
-                        assert numpy.all(ac == ag)
+                    yield run_tril, dtype, shape, order, inplace
+
+@guard_devsup
+def run_tril(dtype, shape, order, inplace):
+    ac, ag = gen_gpuarray(shape, dtype, order=order, ctx=context)
+    result = tril(ag, inplace=inplace)
+    assert numpy.all(numpy.tril(ac) == result)
+    if inplace:
+        assert numpy.all(numpy.tril(ac) == ag)
+    else:
+        assert numpy.all(ac == ag)
 
 
 def test_triu():
@@ -26,14 +29,17 @@ def test_triu():
         for shape in [(10, 5), (5, 10), (10, 10)]:
             for order in ['c', 'f']:
                 for inplace in [True, False]:
-                    ac, ag = gen_gpuarray(shape, dtype,
-                                          order=order, ctx=context)
-                    result = triu(ag, inplace=inplace)
-                    assert numpy.all(numpy.triu(ac) == result)
-                    if inplace:
-                        assert numpy.all(numpy.triu(ac) == ag)
-                    else:
-                        assert numpy.all(ac == ag)
+                    yield run_triu, dtype, shape, order, inplace
+
+@guard_devsup
+def run_triu(dtype, shape, order, inplace):
+    ac, ag = gen_gpuarray(shape, dtype, order=order, ctx=context)
+    result = triu(ag, inplace=inplace)
+    assert numpy.all(numpy.triu(ac) == result)
+    if inplace:
+        assert numpy.all(numpy.triu(ac) == ag)
+    else:
+        assert numpy.all(ac == ag)
 
 
 class test_errors(TestCase):

--- a/pygpu/tests/test_blas.py
+++ b/pygpu/tests/test_blas.py
@@ -14,6 +14,19 @@ except ImportError as e:
     raise SkipTest("no scipy blas to compare against")
 
 import pygpu.blas as gblas
+from pygpu.gpuarray import (GpuArrayException, UnsupportedException)
+
+def guard_devsup_blasdouble(func):
+    def f(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except UnsupportedException as e:
+            raise SkipTest("operation not supported")
+        except GpuArrayException as e:
+            if 'float64' in args and "does not support double precision" in str(e):
+                raise SkipTest("double precision not supported")
+            raise
+    return f
 
 
 def test_dot():
@@ -25,7 +38,7 @@ def test_dot():
         yield dot, 666, 'float32', False, False, overwrite, init_z
 
 
-@guard_devsup
+@guard_devsup_blasdouble
 def dot(N, dtype, offseted_i, sliced, overwrite, init_z):
     cX, gX = gen_gpuarray((N,), dtype, offseted_inner=offseted_i,
                           sliced=sliced, ctx=context)
@@ -61,7 +74,7 @@ def test_gemv():
                overwrite, True, alpha, beta)
 
 
-@guard_devsup
+@guard_devsup_blasdouble
 def gemv(shp, dtype, order, trans, offseted_i, sliced,
          overwrite, init_y, alpha=1.0, beta=0.0):
     cA, gA = gen_gpuarray(shp, dtype, order=order, offseted_inner=offseted_i,
@@ -109,7 +122,7 @@ def test_gemm():
                (False, False), False, 1, overwrite, True, alpha, beta)
 
 
-@guard_devsup
+@guard_devsup_blasdouble
 def gemm(m, n, k, dtype, order, trans, offseted_o, sliced, overwrite,
          init_res, alpha=1.0, beta=0.0):
     if trans[0]:
@@ -153,7 +166,7 @@ def test_ger():
     for init_res, overwrite in product(bools, bools):
         yield ger, 4, 5, 'float32', 'f', 1, 1, init_res, overwrite
 
-
+@guard_devsup_blasdouble
 def ger(m, n, dtype, order, sliced_x, sliced_y, init_res, overwrite=False):
     cX, gX = gen_gpuarray((m,), dtype, order, sliced=sliced_x, ctx=context)
     cY, gY = gen_gpuarray((n,), dtype, order, sliced=sliced_y, ctx=context)
@@ -192,7 +205,7 @@ def test_rgemmBatch_3d():
                (False, False), False, 1, overwrite, True, alpha, beta)
 
 
-@guard_devsup
+@guard_devsup_blasdouble
 def rgemmBatch_3d(b, m, n, k, dtype, order, trans, offseted_o, sliced,
                   overwrite, init_res, alpha=1.0, beta=0.0):
     if trans[0]:

--- a/pygpu/tests/test_elemwise.py
+++ b/pygpu/tests/test_elemwise.py
@@ -318,24 +318,29 @@ neg_infinity() {return -INFINITY;}
 
 def test_infinity():
     for dtype in ['float32', 'float64']:
-        ac, ag = gen_gpuarray((2,), dtype, ctx=context, cls=elemary)
-        out_g = ag._empty_like_me()
-        flt = 'ga_float' if dtype == 'float32' else 'ga_double'
-        out_arg = arg('out', out_g.dtype, scalar=False, read=False, write=True)
-        preamble = _inf_preamb_tpl.render(flt=flt)
+        yield infinity, dtype
 
-        # +infinity
-        ac[:] = numpy.inf
-        expr_inf = 'out = infinity()'
-        kernel = GpuElemwise(context, expr_inf, [out_arg],
-                             preamble=preamble)
-        kernel(out_g)
-        assert numpy.array_equal(ac, numpy.asarray(out_g))
 
-        # -infinity
-        ac[:] = -numpy.inf
-        expr_neginf = 'out = neg_infinity()'
-        kernel = GpuElemwise(context, expr_neginf, [out_arg],
-                             preamble=preamble)
-        kernel(out_g)
-        assert numpy.array_equal(ac, numpy.asarray(out_g))
+@guard_devsup
+def infinity(dtype):
+    ac, ag = gen_gpuarray((2,), dtype, ctx=context, cls=elemary)
+    out_g = ag._empty_like_me()
+    flt = 'ga_float' if dtype == 'float32' else 'ga_double'
+    out_arg = arg('out', out_g.dtype, scalar=False, read=False, write=True)
+    preamble = _inf_preamb_tpl.render(flt=flt)
+
+    # +infinity
+    ac[:] = numpy.inf
+    expr_inf = 'out = infinity()'
+    kernel = GpuElemwise(context, expr_inf, [out_arg],
+                         preamble=preamble)
+    kernel(out_g)
+    assert numpy.array_equal(ac, numpy.asarray(out_g))
+
+    # -infinity
+    ac[:] = -numpy.inf
+    expr_neginf = 'out = neg_infinity()'
+    kernel = GpuElemwise(context, expr_neginf, [out_arg],
+                         preamble=preamble)
+    kernel(out_g)
+    assert numpy.array_equal(ac, numpy.asarray(out_g))

--- a/pygpu/tests/test_reduction.py
+++ b/pygpu/tests/test_reduction.py
@@ -52,8 +52,13 @@ def test_red_big_array():
                   [False, True, False]]:
         yield red_array_sum, 'float32', (2000, 30, 100), redux
 
-
+# this test needs a guard_devsup because Python 'float' is double,
+# and placing one directly on a test_* makes nose not know that it's a test
 def test_red_broadcast():
+    red_broadcast()
+
+@guard_devsup
+def red_broadcast():
     from pygpu.tools import as_argument
 
     dtype = float
@@ -78,7 +83,6 @@ def test_red_broadcast():
 
     assert numpy.allclose(nz, numpy.asarray(gz))
 
-
 def test_reduction_ops():
     for axis in [None, 0, 1]:
         for op in ['all', 'any']:
@@ -88,6 +92,7 @@ def test_reduction_ops():
                 yield reduction_op, op, dtype, axis
 
 
+@guard_devsup
 def reduction_op(op, dtype, axis):
     c, g = gen_gpuarray((2, 3), dtype=dtype, ctx=context, cls=elemary)
 

--- a/pygpu/tools.py
+++ b/pygpu/tools.py
@@ -177,7 +177,6 @@ def lru_cache(maxsize=20):
         @functools.wraps(user_function)
         def wrapper(*key):
             time[0] += 1
-            last_use[key] = time[0]
 
             try:
                 result = cache[key]
@@ -189,11 +188,12 @@ def lru_cache(maxsize=20):
 
                 # purge least recently used cache entries
                 if len(cache) > wrapper.maxsize:
-                    for key, _ in nsmallest(wrapper.maxsize // 10,
+                    for key0, _ in nsmallest(wrapper.maxsize // 10,
                                             six.iteritems(last_use),
                                             key=itemgetter(1)):
-                        del cache[key], last_use[key]
+                        del cache[key0], last_use[key0]
 
+            last_use[key] = time[0]
             return result
 
         def clear():

--- a/src/gpuarray_blas_opencl_clblas.c
+++ b/src/gpuarray_blas_opencl_clblas.c
@@ -35,7 +35,7 @@ static inline clblasTranspose convT(cb_transpose trans) {
 static unsigned int refcnt = 0;
 
 static const char *estr(clblasStatus err) {
-  if (err > -1024)
+  if (err > -900)
     return cl_error_string((cl_int)err);
   switch (err) {
   case clblasNotImplemented:

--- a/src/gpuarray_blas_opencl_clblas.c
+++ b/src/gpuarray_blas_opencl_clblas.c
@@ -35,8 +35,12 @@ static inline clblasTranspose convT(cb_transpose trans) {
 static unsigned int refcnt = 0;
 
 static const char *estr(clblasStatus err) {
-  if (err > -900)
+  if (err > -900) {
+    if (err == CL_INVALID_DEVICE) {
+      return "Invalid device, or double precision requested on a device that does not support double precision";
+    }
     return cl_error_string((cl_int)err);
+  }
   switch (err) {
   case clblasNotImplemented:
     return "Unimplemented feature";

--- a/src/gpuarray_blas_opencl_clblas.c
+++ b/src/gpuarray_blas_opencl_clblas.c
@@ -132,6 +132,7 @@ static int sgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
   cl_uint num_ev = 0;
 
   for (i = 0; i < batchCount; i++) {
+    num_ev = 0;
     ARRAY_INIT(A[i]);
     ARRAY_INIT(B[i]);
     ARRAY_INIT(C[i]);
@@ -163,6 +164,7 @@ static int dgemmBatch(cb_order order, cb_transpose transA, cb_transpose transB,
   cl_uint num_ev = 0;
 
   for (i = 0; i < batchCount; i++) {
+    num_ev = 0;
     ARRAY_INIT(A[i]);
     ARRAY_INIT(B[i]);
     ARRAY_INIT(C[i]);

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -275,7 +275,7 @@ gpudata *cl_make_buf(gpucontext *c, cl_mem buf) {
   CL_CHECKN(ctx->err, clGetMemObjectInfo(buf, CL_MEM_CONTEXT, sizeof(buf_ctx),
                                          &buf_ctx, NULL));
   if (buf_ctx != ctx->ctx) {
-    error_set(ctx->err, GA_VALUE_ERROR, "Requested context doesn't macth object context");
+    error_set(ctx->err, GA_VALUE_ERROR, "Requested context doesn't match object context");
     return NULL;
   }
 

--- a/src/gpuarray_buffer_opencl.c
+++ b/src/gpuarray_buffer_opencl.c
@@ -781,7 +781,9 @@ static int cl_check_extensions(const char **preamble, unsigned int *count,
     (*count)++;
   }
   if (flags & GA_USE_DOUBLE) {
-    GA_CHECK(check_ext(ctx, CL_DOUBLE));
+    if (check_ext(ctx, CL_DOUBLE) != GA_NO_ERROR) {
+      return error_set(ctx->err, GA_DEVSUP_ERROR, "This device does not support double precision (pygpu int/int, int32+float32, and floating point literals default to double precision)");
+    }
     preamble[*count] = PRAGMA CL_DOUBLE ENABLE;
     (*count)++;
   }


### PR DESCRIPTION
i.e. one that actually says that, not a generic "Could not initialize C GpuElemwise instance" or a code that means nothing until looked up.

Also extend "unsupported = skip, not fail" to all tests that use double precision.

There are two places where this reads error message text to determine the error type because the error code isn't passed up the stack: making it be so passed would be more robust, but more interface-breaking.

Motivation / testing note: Intel integrated GPUs are probably the most readily available "no double precision" hardware (the [beignet-opencl-icd](https://packages.debian.org/unstable/beignet-opencl-icd) driver disables it by default on all of them, I think Ivybridge/Haswell lack it at the hardware level).  Unfortunately, they may crash in the BLAS tests (with or without these changes) due to clMathLibraries/clblas#322 and/or clMathLibraries/clblas#321: skip those tests if necessary.

(This is branched off #584 because they touch the same line of code so would merge conflict: they are semantically independent.)