### PR TITLE
Fix for tril, triu when kernel_sched returns LS, GS such that LS*GS < N

### DIFF
--- a/pygpu/basic.py
+++ b/pygpu/basic.py
@@ -2,6 +2,7 @@ from string import Template
 from .gpuarray import GpuArray, GpuKernel, SIZE, dtype_to_ctype
 import numpy
 
+
 def _generate_kernel(ctx, cols, dtype, upper=True):
     tmpl = Template("""
     #include "cluda.h"
@@ -38,6 +39,7 @@ def _generate_kernel(ctx, cols, dtype, upper=True):
                   have_complex=have_complex)
     return k
 
+
 def triu(A, inplace=True):
     if A.ndim != 2:
         raise ValueError("triu only works for 2d arrays")
@@ -59,7 +61,7 @@ def triu(A, inplace=True):
         ls = n
         gs = 1
     else:
-        (gs,r) = divmod(n,ls)
+        (gs, r) = divmod(n, ls)
         if r > 0:
             gs += 1
 
@@ -88,7 +90,7 @@ def tril(A, inplace=True):
         ls = n
         gs = 1
     else:
-        (gs,r) = divmod(n,ls)
+        (gs, r) = divmod(n, ls)
         if r > 0:
             gs += 1
 

--- a/pygpu/basic.py
+++ b/pygpu/basic.py
@@ -38,7 +38,6 @@ def _generate_kernel(ctx, cols, dtype, upper=True):
                   have_complex=have_complex)
     return k
 
-
 def triu(A, inplace=True):
     if A.ndim != 2:
         raise ValueError("triu only works for 2d arrays")
@@ -54,7 +53,17 @@ def triu(A, inplace=True):
         upper = True
         cols = A.shape[1]
     k = _generate_kernel(A.context, cols, A.dtype, upper)
-    k(A, A.offset, A.shape[0] * A.shape[1], n=A.shape[0] * A.shape[1])
+    n = int(A.shape[0]*A.shape[1])
+    ls = 256
+    if n < ls:
+        ls = n
+        gs = 1
+    else:
+        (gs,r) = divmod(n,ls)
+        if r > 0:
+            gs += 1
+
+    k(A, A.offset, A.shape[0] * A.shape[1], ls=ls, gs=gs)
     return A
 
 
@@ -73,5 +82,15 @@ def tril(A, inplace=True):
         upper = False
         cols = A.shape[1]
     k = _generate_kernel(A.context, cols, A.dtype, upper)
-    k(A, A.offset, A.shape[0] * A.shape[1], n=A.shape[0] * A.shape[1])
+    n = int(A.shape[0]*A.shape[1])
+    ls = 256
+    if n < ls:
+        ls = n
+        gs = 1
+    else:
+        (gs,r) = divmod(n,ls)
+        if r > 0:
+            gs += 1
+
+    k(A, A.offset, A.shape[0] * A.shape[1], ls=ls, gs=gs)
     return A


### PR DESCRIPTION
An issue arises from the following discussion:

https://groups.google.com/d/msg/theano-users/lc6uMHU2rn4/Soxjr5c1FQAJ

It is related to issue #438 . The current implementation of `tril`, `triu` and [do_call](https://github.com/Theano/libgpuarray/blob/9cec61435c11cf2ffcf7c480c2d524772585c47f/pygpu/gpuarray.pyx#L2424) do not take into account when the case [kernel_sched](https://github.com/Theano/libgpuarray/blob/9cec61435c11cf2ffcf7c480c2d524772585c47f/src/gpuarray_kernel.c#L38) returns LS and GS such that LS*GS < N.

This PR is a quick fix by computing LS and GS itself and it guarantees LS*GS >= N.
I know that it may not be the most efficient value of LS, GS. 
However, I am not sure the logic behind `kernel_sched` and I believe if I modify it, everything may be affected. Therefore I decided to let `tril` and `triu` compute their own value of LS and GS in `tril` to `triu` to fix it.
