### PR TITLE
Change add_stylesheet to add_css_file

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,7 +116,7 @@ if os.environ.get('READTHEDOCS') != 'True':
     html_theme = 'sphinx_rtd_theme'
 
 def setup(app):
-    app.add_stylesheet('fix_rtd.css')
+    app.add_css_file('fix_rtd.css')
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
`app.add_stylesheet` has been deprecated since Sphinx 1.8.0b1, and has been removed entirely from Sphinx 6.x.